### PR TITLE
Create a user identity

### DIFF
--- a/src/main/java/org/zendesk/client/v2/ZenDesk.java
+++ b/src/main/java/org/zendesk/client/v2/ZenDesk.java
@@ -465,6 +465,16 @@ public class ZenDesk implements Closeable {
         ), handleStatus()));
     }
 
+    public void createUserIdentity(int userId, Identity identity) {
+        complete(submit(req("POST", tmpl("/users/{userId}/identities.json").set("userId", userId), JSON, json(
+             Collections.singletonMap("identity", identity))), handle(Identity.class, "identity")));
+    }
+
+    public void createUserIdentity(User user, Identity identity) {
+        complete(submit(req("POST", tmpl("/users/{userId}/identities.json").set("userId", user.getId()), JSON, json(
+             Collections.singletonMap("identity", identity))), handle(Identity.class, "identity")));
+    }
+
     public Iterable<org.zendesk.client.v2.model.Request> getRequests() {
         return new PagedIterable<org.zendesk.client.v2.model.Request>(cnst("/requests.json"),
                 handleList(org.zendesk.client.v2.model.Request.class, "requests"));


### PR DESCRIPTION
I needed the ability to explicitly create a user identity after the user is created. Specifying identities in a PUT to a user does not update the identities. There may be other needs to create the ability to push many identities for a user at the same time but I thought this would be helpful.
