### PR TITLE
Add empty bodies to some actions

### DIFF
--- a/src/main/java/org/zendesk/client/v2/ZenDesk.java
+++ b/src/main/java/org/zendesk/client/v2/ZenDesk.java
@@ -443,9 +443,9 @@ public class ZenDesk implements Closeable {
     }
 
     public Identity requestVerifyUserIdentity(int userId, int identityId) {
-        return complete(submit(req("PUT", tmpl("/users/{userId}/identities/{identityId}/request_verification")
+        return complete(submit(req("PUT", tmpl("/users/{userId}/identities/{identityId}/request_verification.json")
                 .set("userId", userId)
-                .set("identityId", identityId)), handle(Identity.class, "identity")));
+                .set("identityId", identityId), JSON, ""), handle(Identity.class, "identity")));
     }
 
     public void deleteUserIdentity(User user, Identity identity) {


### PR DESCRIPTION
For whatever reason, the user identity make primary, request verification, and very actions require an empty body per the [Zendesk documentation](http://developer.zendesk.com/documentation/rest_api/user_identities.html#verify-a-given-user-identity) (see the `-d` in the curl statement). Not providing a body causes an exception to be thrown demanding a length.
