### PR TITLE
UTF-8 charset for API request payload.

### DIFF
--- a/src/main/java/org/zendesk/client/v2/ZenDesk.java
+++ b/src/main/java/org/zendesk/client/v2/ZenDesk.java
@@ -28,7 +28,6 @@ import org.zendesk.client.v2.model.User;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -413,7 +412,7 @@ public class ZenDesk implements Closeable {
     public List<Identity> setUserPrimaryIdentity(int userId, int identityId) {
         return complete(submit(req("PUT",
                 tmpl("/users/{userId}/identities/{identityId}/make_primary.json").set("userId", userId)
-                        .set("identityId", identityId), JSON, ""),
+                        .set("identityId", identityId), JSON, null),
                 handleList(Identity.class, "identities")));
     }
 
@@ -430,7 +429,7 @@ public class ZenDesk implements Closeable {
     public Identity verifyUserIdentity(int userId, int identityId) {
         return complete(submit(req("PUT", tmpl("/users/{userId}/identities/{identityId}/verify.json")
                 .set("userId", userId)
-                .set("identityId", identityId), JSON, ""), handle(Identity.class, "identity")));
+                .set("identityId", identityId), JSON, null), handle(Identity.class, "identity")));
     }
 
     public Identity requestVerifyUserIdentity(User user, Identity identity) {
@@ -446,7 +445,7 @@ public class ZenDesk implements Closeable {
     public Identity requestVerifyUserIdentity(int userId, int identityId) {
         return complete(submit(req("PUT", tmpl("/users/{userId}/identities/{identityId}/request_verification.json")
                 .set("userId", userId)
-                .set("identityId", identityId), JSON, ""), handle(Identity.class, "identity")));
+                .set("identityId", identityId), JSON, null), handle(Identity.class, "identity")));
     }
 
     public void deleteUserIdentity(User user, Identity identity) {
@@ -689,14 +688,6 @@ public class ZenDesk implements Closeable {
         return builder.build();
     }
 
-    private Request req(String method, Uri template, String contentType, String body) {
-        try {
-            return req(method, template, contentType, body.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            throw new ZenDeskException(e.getMessage(), e);
-        }
-    }
-
     private Request req(String method, Uri template, String contentType, byte[] body) {
         RequestBuilder builder = new RequestBuilder(method);
         if (realm != null) {
@@ -704,7 +695,7 @@ public class ZenDesk implements Closeable {
         }
         builder.setUrl(template.toString());
         builder.addHeader("Content-type", contentType);
-        builder.setBody(body).setBodyEncoding("UTF-8");
+        builder.setBody(body);
         return builder.build();
     }
 


### PR DESCRIPTION
Charset fix for below exception.

2013-11-20 23:06:50,941 DEBUG [qtp17541138-764](org.zendesk.client.v2.ZenDesk) Request PUT ......
2013-11-20 23:06:51,124 DEBUG [New I/O worker #5](org.zendesk.client.v2.ZenDesk) Response HTTP/422 Unprocessable Entity
{"error":"Unprocessable Entity","message":"Server could not parse JSON"} 
2013-11-20 23:06:51,125 WARN  [qtp17541138-764](org.eclipse.jetty.servlet.ServletHandler)  
org.springframework.web.util.NestedServletException: Request processing failed; nested exception is org.zendesk.client.v2.ZenDeskResponseException: Unprocessable Entity
    at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:948)
    at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:827)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
    at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:812)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
    at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:696)
    at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:526)
    at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1110)
    at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:453)
    at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1044)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
    at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
    at org.eclipse.jetty.server.Server.handle(Server.java:442)
    at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:279)
    at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:213)
    at org.eclipse.jetty.io.AbstractConnection$1.run(AbstractConnection.java:505)
    at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:601)
    at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:532)
    at java.lang.Thread.run(Thread.java:744)
Caused by: org.zendesk.client.v2.ZenDeskResponseException: Unprocessable Entity
    at org.zendesk.client.v2.ZenDesk$3.onCompleted(ZenDesk.java:764)
