### PR TITLE
Make Field.Option public so that it is visible outside the package

### DIFF
--- a/src/main/java/org/zendesk/client/v2/model/Field.java
+++ b/src/main/java/org/zendesk/client/v2/model/Field.java
@@ -208,7 +208,7 @@ public class Field {
         return sb.toString();
     }
 
-    private static class Option {
+    public static class Option {
         private String name;
         private String value;
 


### PR DESCRIPTION
In order to make the field options usable by the client (such as for mimicking the pulldown choices in our own UI), the Option class needs to be public
