### PR TITLE
add support for all comments (public and private)

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -561,6 +561,11 @@ public class Zendesk implements Closeable {
         return new PagedIterable<Comment>(tmpl("/requests/{id}/comments.json").set("id", id),
                 handleList(Comment.class, "comments"));
     }
+    
+    public Iterable<Comment> getTicketComments(long id) {
+        return new PagedIterable<Comment>(tmpl("/tickets/{id}/comments.json").set("id", id),
+                handleList(Comment.class, "comments"));
+    }
 
     public Comment getRequestComment(org.zendesk.client.v2.model.Request request, Comment comment) {
         checkHasId(comment);


### PR DESCRIPTION
One more thing. I noticed that you are getting the comments from the requests API, which is only for public stuff. However, there is also a need sometimes to get private comments associated with a particular ticket. Same model, different API path.

This pull will add that.
