### PR TITLE
Upgrade async-http-client to 1.9.3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.ning</groupId>
       <artifactId>async-http-client</artifactId>
-      <version>1.7.12</version>
+      <version>1.9.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -917,19 +917,15 @@ public class Zendesk implements Closeable {
     }
 
     private <T> ListenableFuture<T> submit(Request request, AsyncCompletionHandler<T> handler) {
-        try {
-            if (request.getStringData() != null) {
-                logger.debug("Request {} {}\n{}", request.getMethod(), request.getUrl(), request.getStringData());
-            } else if (request.getByteData() != null) {
-                logger.debug("Request {} {} {} {} bytes", request.getMethod(), request.getUrl(), //
-                        request.getHeaders().getFirstValue("Content-type"), request.getByteData().length);
-            } else {
-                logger.debug("Request {} {}", request.getMethod(), request.getUrl());
-            }
-            return client.executeRequest(request, handler);
-        } catch (IOException e) {
-            throw new ZendeskException(e.getMessage(), e);
+        if (request.getStringData() != null) {
+            logger.debug("Request {} {}\n{}", request.getMethod(), request.getUrl(), request.getStringData());
+        } else if (request.getByteData() != null) {
+            logger.debug("Request {} {} {} {} bytes", request.getMethod(), request.getUrl(), //
+                    request.getHeaders().getFirstValue("Content-type"), request.getByteData().length);
+        } else {
+            logger.debug("Request {} {}", request.getMethod(), request.getUrl());
         }
+        return client.executeRequest(request, handler);
     }
 
     private Request req(String method, Uri template) {
@@ -963,7 +959,7 @@ public class Zendesk implements Closeable {
         } else {
             builder.addHeader("Authorization", "Bearer " + oauthToken);
         }
-        builder.addQueryParameter("page", Integer.toString(page));
+        builder.addQueryParam("page", Integer.toString(page));
         builder.setUrl(template.toString().replace("%2B", "+")); //replace out %2B with + due to API restriction
         return builder.build();
     }

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -965,7 +965,7 @@ public class Zendesk implements Closeable {
     }
 
     protected AsyncCompletionHandler<Void> handleStatus() {
-        return new AsyncCompletionHandler<Void>() {
+        return new ZendeskCompletionHandler<Void>() {
             @Override
             public Void onCompleted(Response response) throws Exception {
                 logResponse(response);
@@ -979,7 +979,7 @@ public class Zendesk implements Closeable {
 
     @SuppressWarnings("unchecked")
     protected <T> AsyncCompletionHandler<T> handle(final Class<T> clazz) {
-        return new AsyncCompletionHandler<T>() {
+        return new ZendeskCompletionHandler<T>() {
             @Override
             public T onCompleted(Response response) throws Exception {
                 logResponse(response);
@@ -995,7 +995,7 @@ public class Zendesk implements Closeable {
     }
 
     protected <T> AsyncCompletionHandler<T> handle(final Class<T> clazz, final String name) {
-        return new AsyncCompletionHandler<T>() {
+        return new ZendeskCompletionHandler<T>() {
             @Override
             public T onCompleted(Response response) throws Exception {
                 logResponse(response);
@@ -1011,7 +1011,7 @@ public class Zendesk implements Closeable {
     }
 
     protected <T> AsyncCompletionHandler<List<T>> handleList(final Class<T> clazz) {
-        return new AsyncCompletionHandler<List<T>>() {
+        return new ZendeskCompletionHandler<List<T>>() {
             @Override
             public List<T> onCompleted(Response response) throws Exception {
                 logResponse(response);
@@ -1028,7 +1028,7 @@ public class Zendesk implements Closeable {
     }
 
     protected <T> AsyncCompletionHandler<List<T>> handleList(final Class<T> clazz, final String name) {
-        return new AsyncCompletionHandler<List<T>>() {
+        return new ZendeskCompletionHandler<List<T>>() {
             @Override
             public List<T> onCompleted(Response response) throws Exception {
                 logResponse(response);
@@ -1045,7 +1045,7 @@ public class Zendesk implements Closeable {
     }
 
     protected AsyncCompletionHandler<List<SearchResultEntity>> handleSearchList(final String name) {
-        return new AsyncCompletionHandler<List<SearchResultEntity>>() {
+        return new ZendeskCompletionHandler<List<SearchResultEntity>>() {
             @Override
             public List<SearchResultEntity> onCompleted(Response response) throws Exception {
                 logResponse(response);
@@ -1271,6 +1271,17 @@ public class Zendesk implements Closeable {
             }
         }
 
+    }
+
+    private static abstract class ZendeskCompletionHandler<T> extends AsyncCompletionHandler<T> {
+        @Override
+        public void onThrowable(Throwable t) {
+            if (t instanceof IOException) {
+                throw new ZendeskException(t);
+            } else {
+                super.onThrowable(t);
+            }
+        }
     }
 
     public static class Builder {


### PR DESCRIPTION
Hey

This upgrades the version of async-http-client used by the library to 1.9.3.

Two breaking changes had to be fixed:

- `AsyncHttpClient.executeRequest` no longer throws `IOException`s. Instead they're just passed down to the handler. To fix this I added `ZendeskCompletionHandler` whose `onThrowable` wraps the `IOException`s in a `ZendeskException`.
- `RequestBuilder.addQueryParameter` was renamed to `addQueryParam`. Straightforward fix.

I wasn't sure if this merits a major version bump because of the backwards incompatible change in a dependency. I'll leave that decision to you.

This resolves #26.