### PR TITLE
Adding DELETED to Status enum

### DIFF
--- a/src/main/java/org/zendesk/client/v2/model/Status.java
+++ b/src/main/java/org/zendesk/client/v2/model/Status.java
@@ -10,7 +10,8 @@ public enum Status {
     PENDING,
     HOLD,
     SOLVED,
-    CLOSED;
+    CLOSED,
+    DELETED;
 
     @Override
     public String toString() {


### PR DESCRIPTION
'deleted' appears to be a new status from Zendesk. The following exception can occur:
```
org.zendesk.client.v2.ZendeskException: java.lang.IllegalArgumentException: Can not construct instance of org.zendesk.client.v2.model.Status from String value 'deleted': value not one of declared Enum instance names: [new, open, pending, hold, solved, closed]
 at [Source: N/A; line: -1, column: -1] (through reference chain: org.zendesk.client.v2.model.Ticket["status"])
org.zendesk.client.v2.ZendeskException: java.lang.IllegalArgumentException: Can not construct instance of org.zendesk.client.v2.model.Status from String value 'deleted': value not one of declared Enum instance names: [new, open, pending, hold, solved, closed]
 at [Source: N/A; line: -1, column: -1] (through reference chain: org.zendesk.client.v2.model.Ticket["status"])
        at org.zendesk.client.v2.Zendesk.complete(Zendesk.java:1403)
        at org.zendesk.client.v2.Zendesk.access$1000(Zendesk.java:67)
        at org.zendesk.client.v2.Zendesk$PagedIterable$PagedIterator.hasNext(Zendesk.java:1549)
```

This is not in the Zendesk documentation, and I've reached out to them accordingly, but pre-emptive support, given this is occurring in production, seems like a good idea.