### PR TITLE
Add api to search for articles in help center.

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -92,6 +92,7 @@ public class Zendesk implements Closeable {
        result.put("group", Group.class);
        result.put("organization", Organization.class);
        result.put("topic", Topic.class);
+        result.put("article", Article.class);
        return Collections.unmodifiableMap(result);
     }
     
@@ -273,6 +274,11 @@ public class Zendesk implements Closeable {
     public Iterable<Ticket> getTicketsFromSearch(String searchTerm) {
         return new PagedIterable<Ticket>(tmpl("/search.json{?query}").set("query", searchTerm + "+type:ticket"),
                 handleList(Ticket.class, "results"));
+    }
+
+    public Iterable<Article> getArticleFromSearch(String searchTerm) {
+        return new PagedIterable<Article>(tmpl("/help_center/articles/search.json{?query}").set("query", searchTerm),
+                handleList(Article.class, "results"));
     }
 
     public List<Ticket> getTickets(long id, long... ids) {

--- a/src/main/java/org/zendesk/client/v2/model/hc/Article.java
+++ b/src/main/java/org/zendesk/client/v2/model/hc/Article.java
@@ -1,11 +1,12 @@
 package org.zendesk.client.v2.model.hc;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.zendesk.client.v2.model.SearchResultEntity;
 
 import java.util.Date;
 import java.util.List;
 
-public class Article {
+public class Article implements SearchResultEntity {
     /** Automatically assigned when the article is created */
     private Long id;
 


### PR DESCRIPTION
Two changes were made to make searching for an article in the help center.

1. Make `Article` a `SearchResultEntity`, and add it to the list of available searchables.
2. Invoking the API call to the help center search.

@reviewbybees 