### PR TITLE
Download Zendesk article attachments and get articles from next page

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -1200,8 +1200,10 @@ public class Zendesk implements Closeable {
     //////////////////////////////////////////////////////////////////////
 
     /**
-     * @Deprecated use #getArticlesFromPage(int). Same as #getArticlesFromPage(0)
-     * @return
+     * Get first page of articles from help center.
+     *
+     * @deprecated use #getArticlesFromPage(int). Same as #getArticlesFromPage(0)
+     * @return List of Articles.
      */
     @Deprecated
     public List<Article> getArticles() {

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -40,6 +40,7 @@ import org.zendesk.client.v2.model.TwitterMonitor;
 import org.zendesk.client.v2.model.User;
 import org.zendesk.client.v2.model.UserField;
 import org.zendesk.client.v2.model.hc.Article;
+import org.zendesk.client.v2.model.hc.ArticleAttachments;
 import org.zendesk.client.v2.model.hc.Category;
 import org.zendesk.client.v2.model.hc.Section;
 import org.zendesk.client.v2.model.targets.BasecampTarget;
@@ -279,6 +280,11 @@ public class Zendesk implements Closeable {
     public Iterable<Article> getArticleFromSearch(String searchTerm) {
         return new PagedIterable<Article>(tmpl("/help_center/articles/search.json{?query}").set("query", searchTerm),
                 handleList(Article.class, "results"));
+    }
+
+    public List<ArticleAttachments> getAttachmentsFromArticle(Long articleID) {
+        return complete(submit(req("GET", tmpl("/help_center/articles/{?query}/attachments.json").set("query", articleID)),
+                handleList(ArticleAttachments.class, "articles")));
     }
 
     public List<Ticket> getTickets(long id, long... ids) {
@@ -1193,8 +1199,18 @@ public class Zendesk implements Closeable {
     // Action methods for Help Center
     //////////////////////////////////////////////////////////////////////
 
+    /**
+     * @Deprecated use #getArticlesFromPage(int). Same as #getArticlesFromPage(0)
+     * @return
+     */
+    @Deprecated
     public List<Article> getArticles() {
         return complete(submit(req("GET", cnst("/help_center/articles.json")),
+                handleList(Article.class, "articles")));
+    }
+
+    public List<Article> getArticlesFromPage(int page) {
+        return complete(submit(req("GET", tmpl("/help_center/articles.json?page={page}").set("page", page)),
                 handleList(Article.class, "articles")));
     }
 

--- a/src/main/java/org/zendesk/client/v2/model/hc/ArticleAttachments.java
+++ b/src/main/java/org/zendesk/client/v2/model/hc/ArticleAttachments.java
@@ -11,36 +11,56 @@ import java.util.Date;
  */
 public class ArticleAttachments {
 
-    // Automatically assigned when the article attachment is created
+    /**
+     *  Automatically assigned when the article attachment is created
+     */
     private int id;
 
-    // The API url of this article attachment
+    /**
+     *  The API url of this article attachment
+     */
     private String url;
 
-    // Id of the associated article, if present
+    /**
+     *  Id of the associated article, if present
+     */
     private int articleId;
 
-    // The name of the file
+    /**
+     *  The name of the file
+     */
     private String fileName;
 
-    // A full URL where the attachment file can be downloaded
+    /**
+     *  A full URL where the attachment file can be downloaded
+     */
     private String contentUrl;
 
-    // The content type of the file. Example: image/png
+    /**
+     *  The content type of the file. Example: image/png
+     */
     private String contentType;
 
-    // The size of the attachment file in bytes
+    /**
+     *  The size of the attachment file in bytes
+     */
     private int size;
 
-    // If true, the attached file is shown in the dedicated admin UI for inline attachments and
-    // its url can be referenced in the HTML body of the article.
-    // If false, the attachment is listed in the list of attachments. Default is false
+    /**
+     *  If true, the attached file is shown in the dedicated admin UI for inline attachments and
+     *  its url can be referenced in the HTML body of the article.
+     *  If false, the attachment is listed in the list of attachments. Default is false
+     */
     private boolean inline;
 
-    // The time at which the article attachment was created
+    /**
+     *  The time at which the article attachment was created
+     */
     private Date createdAt;
 
-    // The time at which the article attachment was last updated
+    /**
+     *  The time at which the article attachment was last updated
+     */
     private Date updatedAt;
 
     public int getId() {

--- a/src/main/java/org/zendesk/client/v2/model/hc/ArticleAttachments.java
+++ b/src/main/java/org/zendesk/client/v2/model/hc/ArticleAttachments.java
@@ -4,11 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Date;
 
-/**
- * @author schristou88
- *         Date: 8/31/15
- *         Time: 1:39 AM
- */
 public class ArticleAttachments {
 
     /**

--- a/src/main/java/org/zendesk/client/v2/model/hc/ArticleAttachments.java
+++ b/src/main/java/org/zendesk/client/v2/model/hc/ArticleAttachments.java
@@ -1,0 +1,148 @@
+package org.zendesk.client.v2.model.hc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+
+/**
+ * @author schristou88
+ *         Date: 8/31/15
+ *         Time: 1:39 AM
+ */
+public class ArticleAttachments {
+
+    // Automatically assigned when the article attachment is created
+    private int id;
+
+    // The API url of this article attachment
+    private String url;
+
+    // Id of the associated article, if present
+    private int articleId;
+
+    // The name of the file
+    private String fileName;
+
+    // A full URL where the attachment file can be downloaded
+    private String contentUrl;
+
+    // The content type of the file. Example: image/png
+    private String contentType;
+
+    // The size of the attachment file in bytes
+    private int size;
+
+    // If true, the attached file is shown in the dedicated admin UI for inline attachments and
+    // its url can be referenced in the HTML body of the article.
+    // If false, the attachment is listed in the list of attachments. Default is false
+    private boolean inline;
+
+    // The time at which the article attachment was created
+    private Date createdAt;
+
+    // The time at which the article attachment was last updated
+    private Date updatedAt;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    @JsonProperty("article_id")
+    public int getArticleId() {
+        return articleId;
+    }
+
+    public void setArticleId(int articleId) {
+        this.articleId = articleId;
+    }
+
+    @JsonProperty("file_name")
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    @JsonProperty("content_url")
+    public String getContentUrl() {
+        return contentUrl;
+    }
+
+    public void setContentUrl(String contentUrl) {
+        this.contentUrl = contentUrl;
+    }
+
+    @JsonProperty("content_type")
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+
+    @JsonProperty("inline")
+    public boolean isInline() {
+        return inline;
+    }
+
+    public void setInline(boolean inline) {
+        this.inline = inline;
+    }
+
+    @JsonProperty("created_at")
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @JsonProperty("updated_at")
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "ArticleAttachments{" +
+                "id=" + id +
+                ", url='" + url + '\'' +
+                ", articleId=" + articleId +
+                ", fileName='" + fileName + '\'' +
+                ", contentUrl='" + contentUrl + '\'' +
+                ", contentType='" + contentType + '\'' +
+                ", size=" + size +
+                ", inline=" + inline +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                '}';
+    }
+}


### PR DESCRIPTION
* Provide api to download attachments from an article.
* Deprecate `Zendesk.getArticles` as this only obtains the article from the
first page. Instead use `Zendesk.getArticlesFromPage` as this will obtain
the article from the next page.

@reviewbybees @ydubreuil 