### PR TITLE
Changed userId to Long to accommodate values larger than Integer.MAX_…

### DIFF
--- a/src/main/java/org/zendesk/client/v2/model/Identity.java
+++ b/src/main/java/org/zendesk/client/v2/model/Identity.java
@@ -11,7 +11,7 @@ import java.util.Date;
 public class Identity {
     private Long id;
     private String url;
-    private Integer userId;
+    private Long userId;
     private String type;
     private String value;
     private Boolean verified;
@@ -60,11 +60,11 @@ public class Identity {
     }
 
     @JsonProperty("user_id")
-    public Integer getUserId() {
+    public Long getUserId() {
         return userId;
     }
 
-    public void setUserId(Integer userId) {
+    public void setUserId(Long userId) {
         this.userId = userId;
     }
 


### PR DESCRIPTION
…INT.

As of October 24, 2015, Zendesk userIds are already larger than Integer.MAX_INT. This means that for any new client using Zendesk Java code, user IDs in the Identity class will be negative numbers. Most other classes use Long for ids, but this one does not.