### PR TITLE
Update Zendesk services with 2 new macros methods

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -33,6 +33,7 @@ import org.zendesk.client.v2.model.OrganizationField;
 import org.zendesk.client.v2.model.SearchResultEntity;
 import org.zendesk.client.v2.model.Status;
 import org.zendesk.client.v2.model.Ticket;
+import org.zendesk.client.v2.model.TicketResult;
 import org.zendesk.client.v2.model.TicketForm;
 import org.zendesk.client.v2.model.Topic;
 import org.zendesk.client.v2.model.Trigger;
@@ -812,7 +813,7 @@ public class Zendesk implements Closeable {
        map.put("monitored_twitter_handle_id", monitorId);
       
        return complete(submit(req("POST", cnst("/channels/twitter/tickets.json"), JSON,              
-             json(Collections.singletonMap("ticket", map ))),
+             json(Collections.singletonMap("ticket", map))),
              handle(Ticket.class, "ticket")));
     }
     
@@ -931,6 +932,18 @@ public class Zendesk implements Closeable {
     public Iterable<Macro> getMacros(){
         return new PagedIterable<Macro>(cnst("/macros.json"),
                 handleList(Macro.class, "macros"));
+    }
+
+    public Ticket macrosShowChangesToTicket(long macroId) {
+        return complete(submit(req("GET", tmpl("/macros/{id}/apply.json").set("id", macroId)),
+                handle(TicketResult.class, "result"))).getTicket();
+    }
+
+    public Ticket macrosShowTicketAfterChanges(long ticketId, long macroId) {
+        return complete(submit(req("GET", tmpl("/tickets/{ticket_id}/macros/{id}/apply.json")
+                        .set("ticket_id", ticketId)
+                        .set("id", macroId)),
+                handle(TicketResult.class, "result"))).getTicket();
     }
 
     public List<String> addTagToTicket(long id, String... tags) {

--- a/src/main/java/org/zendesk/client/v2/model/TicketResult.java
+++ b/src/main/java/org/zendesk/client/v2/model/TicketResult.java
@@ -1,0 +1,20 @@
+package org.zendesk.client.v2.model;
+
+public class TicketResult {
+    private Ticket ticket;
+
+    public TicketResult() {
+    }
+
+    public TicketResult(Ticket ticket) {
+        this.ticket = ticket;
+    }
+
+    public Ticket getTicket() {
+        return ticket;
+    }
+
+    public void setTicket(Ticket ticket) {
+        this.ticket = ticket;
+    }
+}

--- a/src/test/java/org/zendesk/client/v2/model/TicketResultTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/TicketResultTest.java
@@ -1,0 +1,29 @@
+package org.zendesk.client.v2.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TicketResultTest {
+
+    private TicketResult parseJson(byte[] json) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.readValue(json, TicketResult.class);
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+
+    @Test
+    public void testParseTicketResult() {
+        String json = "{ \"ticket\": { \"id\": 21337631753}}";
+        TicketResult ev = parseJson(json.getBytes());
+        assertNotNull(ev);
+        assertEquals(TicketResult.class, ev.getClass());
+    }
+
+}


### PR DESCRIPTION
We needed to apply macros to tickets (in order to send emails to users thanks to some zendesk macros).
Here the list of changes:
* [Show Changes to Ticket](https://developer.zendesk.com/rest_api/docs/core/macros#show-changes-to-ticket)
* [Show Ticket After Changes](https://developer.zendesk.com/rest_api/docs/core/macros#show-ticket-after-changes)