### PR TITLE
Fix getArticles to retrieve multiple pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Here is the status of the various API components:
 * [Topics](http://developer.zendesk.com/documentation/rest_api/topics.html) ✓
 * [Topic Comments](http://developer.zendesk.com/documentation/rest_api/topic_comments.html)
 * [Topic Subscriptions](http://developer.zendesk.com/documentation/rest_api/topic_subscriptions.html)
+* [Help Center Categories](https://developer.zendesk.com/rest_api/docs/help_center/categories)
+* [Help Center Sections](https://developer.zendesk.com/rest_api/docs/help_center/sections)
+* [Help Center Articles](https://developer.zendesk.com/rest_api/docs/help_center/articles)
 * [Topic Votes](http://developer.zendesk.com/documentation/rest_api/topic_votes.html)
 * [Account Settings](http://developer.zendesk.com/documentation/rest_api/account_settings.html)
 * [Activity Stream](http://developer.zendesk.com/documentation/rest_api/activity_stream.html)

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -1209,15 +1209,13 @@ public class Zendesk implements Closeable {
     //////////////////////////////////////////////////////////////////////
 
     /**
-     * Get first page of articles from help center.
+     * Get all articles from help center.
      *
-     * @deprecated use #getArticlesFromPage(int). Same as #getArticlesFromPage(0)
      * @return List of Articles.
      */
-    @Deprecated
-    public List<Article> getArticles() {
-        return complete(submit(req("GET", cnst("/help_center/articles.json")),
-                handleList(Article.class, "articles")));
+    public Iterable<Article> getArticles() {
+        return new PagedIterable<Article>(cnst("/help_center/articles.json"),
+                handleList(Article.class, "articles"));
     }
 
     public List<Article> getArticlesFromPage(int page) {

--- a/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
+++ b/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
@@ -17,6 +17,7 @@ import org.zendesk.client.v2.model.Ticket;
 import org.zendesk.client.v2.model.TicketForm;
 import org.zendesk.client.v2.model.User;
 import org.zendesk.client.v2.model.events.Event;
+import org.zendesk.client.v2.model.hc.Article;
 import org.zendesk.client.v2.model.targets.Target;
 
 import java.util.ArrayList;
@@ -476,4 +477,15 @@ public class RealSmokeTest {
         }
     }
 
+    @Test
+    public void getArticles() throws Exception {
+        createClientWithTokenOrPassword();
+        int count = 0;
+        for (Article t : instance.getArticles()) {
+            assertThat(t.getTitle(), notNullValue());
+            if (++count > 40) {  // Check enough to pull 2 result pages
+                break;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Remove deprecation tag, as the method now returns articles across multiple result pages