### PR TITLE
Add API Support to attachment in Articles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>com.cloudbees.thirdparty</groupId>
   <artifactId>zendesk-java-client</artifactId>
-  <version>0.3.2-SNAPSHOT</version>
+  <version>0.3.3-SNAPSHOT</version>
 
   <name>zendesk-java-client</name>
   <description>Java client for the Zendesk API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>com.cloudbees.thirdparty</groupId>
   <artifactId>zendesk-java-client</artifactId>
-  <version>0.3.3-SNAPSHOT</version>
+  <version>0.3.2-SNAPSHOT</version>
 
   <name>zendesk-java-client</name>
   <description>Java client for the Zendesk API</description>

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -491,27 +491,27 @@ public class Zendesk implements Closeable {
     }
 
   public void associateAttachmentsToArticle(String idArticle, List<Attachment> attachments) {
-     TemplateUri uri = tmpl("/help_center/articles/{article_id}/bulk_attachments.json").set("article_id", idArticle);
-     List<Long> attachmentsIds = new ArrayList<Long>();
-     for(Attachment item : attachments){
-       attachmentsIds.add(item.getId());
-     }
-     complete(submit(req("POST", uri, JSON, json(Collections.singletonMap("attachment_ids", attachmentsIds))), handleStatus()));
- }
+        TemplateUri uri = tmpl("/help_center/articles/{article_id}/bulk_attachments.json").set("article_id", idArticle);
+        List<Long> attachmentsIds = new ArrayList<Long>();
+        for(Attachment item : attachments){
+            attachmentsIds.add(item.getId());
+        }
+        complete(submit(req("POST", uri, JSON, json(Collections.singletonMap("attachment_ids", attachmentsIds))), handleStatus()));
+    }
    
   public ArticleAttachments createUploadArticle(long articleId, File file) throws IOException {
-    BoundRequestBuilder builder = client.preparePost(tmpl("/help_center/articles/{id}/attachments.json").set("id", articleId).toString());
-    if (realm != null) {
-      builder.setRealm(realm);
-    } else {
-      builder.addHeader("Authorization", "Bearer " + oauthToken);
+        BoundRequestBuilder builder = client.preparePost(tmpl("/help_center/articles/{id}/attachments.json").set("id", articleId).toString());
+        if (realm != null) {
+            builder.setRealm(realm);
+        } else {
+            builder.addHeader("Authorization", "Bearer " + oauthToken);
+        }
+        builder.setHeader("Content-Type", "multipart/form-data");
+        builder.addBodyPart(
+            new FilePart("file", file, "application/octet-stream", Charset.forName("UTF-8"), file.getName()));
+        final Request req = builder.build();
+        return complete(submit(req, handle(ArticleAttachments.class, "article_attachment")));
     }
-    builder.setHeader("Content-Type", "multipart/form-data");
-    builder.addBodyPart(
-        new FilePart("file", file, "application/octet-stream", Charset.forName("UTF-8"), file.getName()));
-    final Request req = builder.build();
-    return complete(submit(req, handle(ArticleAttachments.class, "article_attachment")));
-  }
   
     public void deleteUpload(Attachment.Upload upload) {
         checkHasToken(upload);
@@ -1405,10 +1405,10 @@ public class Zendesk implements Closeable {
      * @param attachment 
      */
     public void deleteArticleAttachment(ArticleAttachments attachment) {
-      if (attachment.getId() == 0) {
-        throw new IllegalArgumentException("Attachment requires id");
-      }
-      deleteArticleAttachment(attachment.getId());
+        if (attachment.getId() == 0) {
+            throw new IllegalArgumentException("Attachment requires id");
+        }
+        deleteArticleAttachment(attachment.getId());
     }
 
     /**
@@ -1416,7 +1416,7 @@ public class Zendesk implements Closeable {
      * @param id attachment identifier. 
      */
     public void deleteArticleAttachment(long id) {
-      complete(submit(req("DELETE", tmpl("/help_center/articles/attachments/{id}.json").set("id", id)), handleStatus()));
+        complete(submit(req("DELETE", tmpl("/help_center/articles/attachments/{id}.json").set("id", id)), handleStatus()));
     }
     
     public List<Category> getCategories() {


### PR DESCRIPTION
new API calls to upload and delete article's attachments, also it fix a bug when you are listing attachments from an article, the previous version, return articles instead of article's attachments.