### PR TITLE
Adding html and plain text fields to Comment.

### DIFF
--- a/src/main/java/org/zendesk/client/v2/model/Comment.java
+++ b/src/main/java/org/zendesk/client/v2/model/Comment.java
@@ -17,6 +17,8 @@ public class Comment implements Serializable {
 
     private Long id;
     private String body;
+    private String plainBody;
+    private String htmlBody;
     private Long authorId;
     private List<String> uploads;
     private List<Attachment> attachments;
@@ -41,6 +43,24 @@ public class Comment implements Serializable {
 
     public void setBody(String body) {
         this.body = body;
+    }
+
+    @JsonProperty("plain_body")
+    public String getPlainBody() {
+        return plainBody;
+    }
+
+    public void setPlainBody(String plainBody) {
+        this.plainBody = plainBody;
+    }
+
+    @JsonProperty("html_body")
+    public String getHtmlBody() {
+        return htmlBody;
+    }
+
+    public void setHtmlBody(String htmlBody) {
+        this.htmlBody = htmlBody;
     }
 
     public List<String> getUploads() {


### PR DESCRIPTION
As per the API documentation located at https://developer.zendesk.com/rest_api/docs/core/ticket_comments, there are html_body and plain_body are options for a Comment. I've added these two fields as we needed to be able to submit HTML formatted tickets. It would be nice if this could be merged so we don't have to depend on our forked version.