### PR TITLE
Add method to inline an article attachment.

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -515,9 +515,16 @@ public class Zendesk implements Closeable {
             attachmentsIds.add(item.getId());
         }
         complete(submit(req("POST", uri, JSON, json(Collections.singletonMap("attachment_ids", attachmentsIds))), handleStatus()));
-    }
+  }
 
+    /**
+     * Create upload article with inline false
+     */
   public ArticleAttachments createUploadArticle(long articleId, File file) throws IOException {
+        return createUploadArticle(articleId, file, false);
+  }
+
+  public ArticleAttachments createUploadArticle(long articleId, File file, boolean inline) throws IOException {
         BoundRequestBuilder builder = client.preparePost(tmpl("/help_center/articles/{id}/attachments.json").set("id", articleId).toString());
         if (realm != null) {
             builder.setRealm(realm);
@@ -525,7 +532,11 @@ public class Zendesk implements Closeable {
             builder.addHeader("Authorization", "Bearer " + oauthToken);
         }
         builder.setHeader("Content-Type", "multipart/form-data");
-        builder.addBodyPart(
+
+        if (inline)
+            builder.addFormParam("inline", "true");
+
+      builder.addBodyPart(
             new FilePart("file", file, "application/octet-stream", Charset.forName("UTF-8"), file.getName()));
         final Request req = builder.build();
         return complete(submit(req, handle(ArticleAttachments.class, "article_attachment")));
@@ -1567,9 +1578,7 @@ public class Zendesk implements Closeable {
      * @param attachment
      */
     public void deleteArticleAttachment(ArticleAttachments attachment) {
-        if (attachment.getId() == 0) {
-            throw new IllegalArgumentException("Attachment requires id");
-        }
+        checkHasId(attachment);
         deleteArticleAttachment(attachment.getId());
     }
 
@@ -2141,6 +2150,12 @@ public class Zendesk implements Closeable {
 
     private static void checkHasId(Attachment attachment) {
         if (attachment.getId() == null) {
+            throw new IllegalArgumentException("Attachment requires id");
+        }
+    }
+
+    private static void checkHasId(ArticleAttachments attachments) {
+        if (attachments.getId() == null) {
             throw new IllegalArgumentException("Attachment requires id");
         }
     }

--- a/src/main/java/org/zendesk/client/v2/model/hc/ArticleAttachments.java
+++ b/src/main/java/org/zendesk/client/v2/model/hc/ArticleAttachments.java
@@ -9,7 +9,7 @@ public class ArticleAttachments {
     /**
      *  Automatically assigned when the article attachment is created
      */
-    private Integer id;
+    private Long id;
 
     /**
      *  The API url of this article attachment
@@ -58,11 +58,11 @@ public class ArticleAttachments {
      */
     private Date updatedAt;
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/org/zendesk/client/v2/model/hc/ArticleAttachments.java
+++ b/src/main/java/org/zendesk/client/v2/model/hc/ArticleAttachments.java
@@ -9,7 +9,7 @@ public class ArticleAttachments {
     /**
      *  Automatically assigned when the article attachment is created
      */
-    private int id;
+    private Integer id;
 
     /**
      *  The API url of this article attachment
@@ -58,11 +58,11 @@ public class ArticleAttachments {
      */
     private Date updatedAt;
 
-    public int getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 


### PR DESCRIPTION
According to: https://developer.zendesk.com/rest_api/docs/help_center/article_attachments#create-article-attachment

the curl command:

```
curl https://{subdomain}.zendesk.com/api/v2/help_center/articles/{id}/attachments.json \
  -F "inline=true" -F "file=@drawing.png" \
  -v -u {email_address}:{password} -X POST
```

Lets you set the inline option when creating the attachment for the first time. It will allow you to create an attachment without it having to be part of the attachments page.

@reviewbybees 