### PR TITLE
Fixing updateUserIdentity(...) Method

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -834,7 +834,7 @@ public class Zendesk implements Closeable {
         checkHasId(identity);
         return complete(submit(req("PUT", tmpl("/users/{userId}/identities/{identityId}.json")
                 .set("userId", userId)
-                .set("identityId", identity.getId()), JSON, null), handle(Identity.class, "identity")));
+                .set("identityId", identity.getId()), JSON, json(Collections.singletonMap("identity", identity))), handle(Identity.class, "identity")));
     }
 
     public Identity updateUserIdentity(User user, Identity identity) {


### PR DESCRIPTION
# Overview

Previously, the "identity" field in the request was not set, which meant that nothing was ever updated.

This fix sets the "identity" field and the update now works as expected.