### PR TITLE
Add additional attributes for Photo found in API responses

### DIFF
--- a/src/main/java/org/zendesk/client/v2/model/Photo.java
+++ b/src/main/java/org/zendesk/client/v2/model/Photo.java
@@ -2,21 +2,28 @@ package org.zendesk.client.v2.model;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author stephenc
  * @since 05/04/2013 15:36
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Photo implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
     private Long id;
     private String fileName;
+    private String url;
     private String contentUrl;
+    private String mappedContentUrl;
     private String contentType;
     private Long size;
+    private Long width;
+    private Long height;
+    private Boolean inline;
 
     @JsonProperty("content_type")
     public String getContentType() {
@@ -27,6 +34,14 @@ public class Photo implements Serializable {
         this.contentType = contentType;
     }
 
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
     @JsonProperty("content_url")
     public String getContentUrl() {
         return contentUrl;
@@ -34,6 +49,15 @@ public class Photo implements Serializable {
 
     public void setContentUrl(String contentUrl) {
         this.contentUrl = contentUrl;
+    }
+
+    @JsonProperty("mapped_content_url")
+    public String getMappedContentUrl() {
+        return mappedContentUrl;
+    }
+
+    public void setMappedContentUrl(String mappedContentUrl) {
+        this.mappedContentUrl = mappedContentUrl;
     }
 
     @JsonProperty("file_name")
@@ -61,6 +85,30 @@ public class Photo implements Serializable {
         this.size = size;
     }
 
+    public Long getWidth() {
+        return width;
+    }
+
+    public void setWidth(Long width) {
+        this.width = width;
+    }
+
+    public Long getHeight() {
+        return height;
+    }
+
+    public Boolean getInline() {
+        return inline;
+    }
+
+    public void setInline(Boolean inline) {
+        this.inline = inline;
+    }
+
+    public void setHeight(Long height) {
+        this.height = height;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -70,6 +118,9 @@ public class Photo implements Serializable {
         sb.append(", fileName='").append(fileName).append('\'');
         sb.append(", contentUrl='").append(contentUrl).append('\'');
         sb.append(", size=").append(size);
+        sb.append(", width=").append(width);
+        sb.append(", height=").append(height);
+        sb.append(", inline=").append(inline);
         sb.append('}');
         return sb.toString();
     }


### PR DESCRIPTION
(Note: I use the models in your package separately from the client, because I am on Google App Engine, where only `URLFetch` is allowed. I'm unsure if the same issue would happen with your client!)

I started to get a bunch of errors like this while parsing user search results:

```
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "url" (class org.zendesk.client.v2.model.Attachment), not marked as ignorable (6 known properties: "content_type", "size", "thumbnails", "content_url", "id", "file_name"])
 at [Source: [B@70410355; line: 1, column: 316] (through reference chain: premise.proxy.mobile.dto.ZdUserSearchResult["users"]->java.util.ArrayList[0]->org.zendesk.client.v2.model.User["photo"]->org.zendesk.client.v2.model.Attachment["url"])
```

So, I looked at the raw JSON returned, and the shape is like this:

```
      "photo": {
        "url": "https://...",
        "id": 1040994207,
        "file_name": "...",
        "content_url": "https://..",
        "mapped_content_url": "https://....",
        "content_type": "image/png",
        "size": 12557,
        "width": 80,
        "height": 80,
        "inline": false,
        "thumbnails": [
          {
            "url": "https://....",
            "id": 1040994227,
            "file_name": "...",
            "content_url": "https://...",
            "mapped_content_url": "https://////",
            "content_type": "image/png",
            "size": 12557,
            "width": 32,
            "height": 32,
            "inline": false
          }
        ]
      },
```

So, I added fields for all of those missing (`url`, `mapped_content_url`, `width`, `height`, and `inline`), and to future-proof, I also added a `@JsonIgnoreProperties(ignoreUnknown = true)` annotation on the class.