### PR TITLE
Include response body in stacktrace message

### DIFF
--- a/src/main/java/org/zendesk/client/v2/ZendeskResponseException.java
+++ b/src/main/java/org/zendesk/client/v2/ZendeskResponseException.java
@@ -21,7 +21,7 @@ public class ZendeskResponseException extends ZendeskException {
     }
 
     public ZendeskResponseException(int statusCode, String statusText, String body) {
-        super(MessageFormat.format("HTTP/{0}: {1}", statusCode, statusText));
+        super(MessageFormat.format("HTTP/{0}: {1} - {2}", statusCode, statusText, body));
         this.statusCode = statusCode;
         this.statusText = statusText;
         this.body = body;


### PR DESCRIPTION
This provides the necessary context when logging a
ZendeskResponseException