### PR TITLE
[fix #213] Upgrade Java requirement to 1.8 + Verify JDK API compat (Animal Sniffer) + Enforce bytecode max version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
     <url>https://opensource.ci.cloudbees.com/job/zendesk-java-client/</url>
   </ciManagement>
 
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -142,15 +147,64 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <source>1.5</source>
-            <target>1.5</target>
-          </configuration>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0-M1</version>
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <fail>true</fail>
+        </configuration>
+        <executions>
+          <execution>
+            <id>check-java-compat</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <rules>
+                <checkSignatureRule implementation="org.codehaus.mojo.animal_sniffer.enforcer.CheckSignatureRule">
+                  <signature>
+                    <groupId>org.codehaus.mojo.signature</groupId>
+                    <artifactId>java18</artifactId>
+                    <version>1.0</version>
+                  </signature>
+                </checkSignatureRule>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-bytecode-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.8</maxJdkVersion>
+                </enforceBytecodeVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-enforcer-rule</artifactId>
+            <version>1.14</version>
+          </dependency>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.0-beta-6</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
   </build>
 
 </project>


### PR DESCRIPTION
@johnou @stephenc as you will see in few minutes in CI:

```
[INFO] Restricted to JDK 1.7 yet org.asynchttpclient:netty-codec-dns:jar:2.0.38:compile contains io/netty/channel/socket/InternetProtocolFamily2.class targeted to JDK 1.8
[INFO] Restricted to JDK 1.7 yet org.asynchttpclient:async-http-client:jar:2.0.38:compile contains org/asynchttpclient/BoundRequestBuilder.class targeted to JDK 1.8
[INFO] Restricted to JDK 1.7 yet org.asynchttpclient:netty-resolver-dns:jar:2.0.38:compile contains io/netty/channel/ReflectiveChannelFactory.class targeted to JDK 1.8
[INFO] Restricted to JDK 1.7 yet org.asynchttpclient:async-http-client-netty-utils:jar:2.0.38:compile contains org/asynchttpclient/netty/util/ByteBufUtils.class targeted to JDK 1.8
[INFO] Restricted to JDK 1.7 yet org.asynchttpclient:netty-resolver:jar:2.0.38:compile contains io/netty/resolver/AbstractAddressResolver.class targeted to JDK 1.8
```

We cannot target Java 7 with the current deps we have