### PR TITLE
Updated setOrganizationMembershipAsDefault to match Zendesk API

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -1497,9 +1497,9 @@ public class Zendesk implements Closeable {
 
     public List<OrganizationMembership> setOrganizationMembershipAsDefault(long user_id, OrganizationMembership organizationMembership) {
 	checkHasId(organizationMembership);
-	return complete(submit(req("POST", tmpl("/users/{uid}/organization_memberships/{gmid}/make_default.json")
-			.set("uid", user_id).set("gmid", organizationMembership.getId()), JSON, json(
-			Collections.singletonMap("group_memberships", organizationMembership))),
+	return complete(submit(req("PUT", tmpl("/users/{uid}/organization_memberships/{omid}/make_default.json")
+			.set("uid", user_id).set("omid", organizationMembership.getId()), JSON, json(
+			Collections.singletonMap("organization_memberships", organizationMembership))),
 		handleList(OrganizationMembership.class, "results")));
     }
     //-- END BETA


### PR DESCRIPTION
Fixed InvalidEndpoint error by converting POST to PUT and updated JSON response to return "organization_memberships" instead of "group_memberships".

https://developer.zendesk.com/rest_api/docs/core/organization_memberships\#set-membership-as-default