### PR TITLE
int to long for Macro dto.

### DIFF
--- a/src/main/java/org/zendesk/client/v2/model/Macro.java
+++ b/src/main/java/org/zendesk/client/v2/model/Macro.java
@@ -17,7 +17,7 @@ public class Macro implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private int id;
+    private long id;
     private String title;
     private boolean active;
     private List<Action> actions;
@@ -26,11 +26,11 @@ public class Macro implements Serializable {
 
     public Macro() {}
 
-    public int getId() {
+    public long getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(long id) {
         this.id = id;
     }
 


### PR DESCRIPTION
org.zendesk.client.v2.ZendeskException: java.lang.IllegalArgumentException: Numeric value (360001871809) out of range of int (-2147483648 - 2147483647)
 at [Source: UNKNOWN; line: -1, column: -1]
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.zendesk.client.v2.model.Macro["id"])
	at org.zendesk.client.v2.Zendesk.complete(Zendesk.java:2199)
	at org.zendesk.client.v2.Zendesk.access$1400(Zendesk.java:93)
