### PR TITLE
User Identity Update fix

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -899,7 +899,7 @@ public class Zendesk implements Closeable {
         checkHasId(identity);
         return complete(submit(req("PUT", tmpl("/users/{userId}/identities/{identityId}.json")
                 .set("userId", userId)
-                .set("identityId", identity.getId()), JSON, null), handle(Identity.class, "identity")));
+                .set("identityId", identity.getId()), JSON, json(Collections.singletonMap("identity", identity))), handle(Identity.class, "identity")));
     }
 
     public Identity updateUserIdentity(User user, Identity identity) {

--- a/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
+++ b/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
@@ -379,8 +379,6 @@ public class RealSmokeTest {
     }
 
     @Test
-    @Ignore("Failing and I don't know why")
-    // TODO: Fix this test
     public void updateUserIdentity() throws Exception {
         createClientWithTokenOrPassword();
         User user = instance.getCurrentUser();


### PR DESCRIPTION
Re-submit of the #243 with Test uncommented. 

Endpoitn in question https://developer.zendesk.com/rest_api/docs/support/user_identities#update-identity

It expects a JSON object with one field `identity` which this PR delivers. Hopefully, the automated test pass as well and #243 and #161 can be closed.