### PR TITLE
Find articles using locale.

### DIFF
--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -1910,6 +1910,11 @@ public class Zendesk implements Closeable {
                 handleList(Article.class, "articles"));
     }
 
+    public Iterable<Article> getArticles(String locale) {
+        return new PagedIterable<>(tmpl("/help_center/{locale}/articles.json").set("locale", locale),
+                                   handleList(Article.class, "articles"));
+    }
+
     public Iterable<Article> getArticles(Category category) {
         checkHasId(category);
         return new PagedIterable<>(


### PR DESCRIPTION
The no arg function now just redirects to the locale version.  Adding an override to make `getArticles` work again.