### PR TITLE
Add various "Many" create/update/delete methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,12 @@
       <version>1.8</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.0.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -1264,6 +1264,28 @@ public class Zendesk implements Closeable {
                                 organizationMembership))), handle(OrganizationMembership.class, "organization_membership")));
     }
 
+    /**
+     * https://developer.zendesk.com/rest_api/docs/support/organization_memberships#create-many-memberships
+     */
+    public JobStatus<OrganizationMembership> createOrganizationMemberships(OrganizationMembership... organizationMemberships) {
+        return createOrganizationMemberships(Arrays.asList(organizationMemberships));
+    }
+
+    /**
+     * https://developer.zendesk.com/rest_api/docs/support/organization_memberships#create-many-memberships
+     */
+    public JobStatus createOrganizationMemberships(List<OrganizationMembership> organizationMemberships) {
+        return complete(createOrganizationMembershipsAsync(organizationMemberships));
+    }
+
+    /**
+     * https://developer.zendesk.com/rest_api/docs/support/organization_memberships#create-many-memberships
+     */
+    public ListenableFuture<JobStatus<OrganizationMembership>> createOrganizationMembershipsAsync(List<OrganizationMembership> organizationMemberships) {
+        return submit(req("POST", cnst("/organization_memberships/create_many.json"), JSON, json(
+                Collections.singletonMap("organization_memberships", organizationMemberships))), handleJobStatus(OrganizationMembership.class));
+    }
+
     public void deleteOrganizationMembership(long id) {
         complete(submit(req("DELETE", tmpl("/organization_memberships/{id}.json").set("id", id)), handleStatus()));
     }

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -203,25 +203,27 @@ public class Zendesk implements Closeable {
     // Action methods
     //////////////////////////////////////////////////////////////////////
 
-    public <T> JobStatus<T> getJobStatus(JobStatus<T> status) {
+    public JobStatus getJobStatus(JobStatus status) {
         return complete(getJobStatusAsync(status));
     }
 
-    public <T> ListenableFuture<JobStatus<T>> getJobStatusAsync(JobStatus<T> status) {
-        return submit(req("GET", tmpl("/job_statuses/{id}.json").set("id", status.getId())), handleJobStatus(status.getResultsClass()));
+    public ListenableFuture<JobStatus> getJobStatusAsync(JobStatus status) {
+        return submit(req("GET", tmpl("/job_statuses/{id}.json").set("id", status.getId())),
+                handleJobStatus());
     }
 
-    public List<JobStatus<HashMap<String, Object>>> getJobStatuses(List<JobStatus> statuses) {
+    public List<JobStatus> getJobStatuses(List<JobStatus> statuses) {
         return complete(getJobStatusesAsync(statuses));
     }
 
-    public ListenableFuture<List<JobStatus<HashMap<String, Object>>>> getJobStatusesAsync(List<JobStatus> statuses) {
+    public ListenableFuture<List<JobStatus>> getJobStatusesAsync(List<JobStatus> statuses) {
         List<String> ids = new ArrayList<>(statuses.size());
         for (JobStatus status : statuses) {
             ids.add(status.getId());
         }
-        Class<JobStatus<HashMap<String, Object>>> clazz = (Class<JobStatus<HashMap<String, Object>>>)(Object)JobStatus.class;
-        return submit(req("GET", tmpl("/job_statuses/show_many.json{?ids}").set("ids", ids)), handleList(clazz, "job_statuses"));
+        Class<JobStatus> clazz = (Class<JobStatus>) (Object) JobStatus.class;
+        return submit(req("GET", tmpl("/job_statuses/show_many.json{?ids}").set("ids", ids)),
+                handleList(clazz, "job_statuses"));
     }
 
     public List<Brand> getBrands(){
@@ -250,17 +252,17 @@ public class Zendesk implements Closeable {
                 handle(Ticket.class, "ticket")));
     }
 
-    public JobStatus<Ticket> importTickets(TicketImport... ticketImports) {
+    public JobStatus importTickets(TicketImport... ticketImports) {
         return importTickets(Arrays.asList(ticketImports));
     }
 
-    public JobStatus<Ticket> importTickets(List<TicketImport> ticketImports) {
+    public JobStatus importTickets(List<TicketImport> ticketImports) {
         return complete(importTicketsAsync(ticketImports));
     }
 
-    public ListenableFuture<JobStatus<Ticket>> importTicketsAsync(List<TicketImport> ticketImports) {
+    public ListenableFuture<JobStatus> importTicketsAsync(List<TicketImport> ticketImports) {
         return submit(req("POST", cnst("/imports/tickets/create_many.json"), JSON, json(
-                Collections.singletonMap("tickets", ticketImports))), handleJobStatus(Ticket.class));
+                Collections.singletonMap("tickets", ticketImports))), handleJobStatus());
     }
 
     public Ticket getTicket(long id) {
@@ -276,11 +278,6 @@ public class Zendesk implements Closeable {
     public List<User> getTicketCollaborators(long id) {
         return complete(submit(req("GET", tmpl("/tickets/{id}/collaborators.json").set("id", id)),
                 handleList(User.class, "users")));
-    }
-
-    public JobStatus permanentlyDeleteTicket(Ticket ticket) {
-        checkHasId(ticket);
-        return permanentlyDeleteTicket(ticket.getId());
     }
 
     /**
@@ -309,17 +306,22 @@ public class Zendesk implements Closeable {
         complete(submit(req("DELETE", tmpl("/tickets/{id}.json").set("id", id)), handleStatus()));
     }
 
+    public JobStatus permanentlyDeleteTicket(Ticket ticket) {
+        checkHasId(ticket);
+        return permanentlyDeleteTicket(ticket.getId());
+    }
+
     public JobStatus permanentlyDeleteTicket(long id) {
         return complete(submit(
                 req("DELETE", tmpl("/deleted_tickets/{id}.json").set("id", id)),
-                handleJobStatus(JobStatus.class))
+                handleJobStatus())
         );
     }
 
-    public ListenableFuture<JobStatus<Ticket>> queueCreateTicketAsync(Ticket ticket) {
+    public ListenableFuture<JobStatus> queueCreateTicketAsync(Ticket ticket) {
         return submit(req("POST", cnst("/tickets.json?async=true"),
                 JSON, json(Collections.singletonMap("ticket", ticket))),
-                handleJobStatus(Ticket.class));
+                handleJobStatus());
     }
 
     public ListenableFuture<Ticket> createTicketAsync(Ticket ticket) {
@@ -332,17 +334,17 @@ public class Zendesk implements Closeable {
         return complete(createTicketAsync(ticket));
     }
 
-    public JobStatus<Ticket> createTickets(Ticket... tickets) {
+    public JobStatus createTickets(Ticket... tickets) {
         return createTickets(Arrays.asList(tickets));
     }
 
-    public JobStatus<Ticket> createTickets(List<Ticket> tickets) {
+    public JobStatus createTickets(List<Ticket> tickets) {
         return complete(createTicketsAsync(tickets));
     }
 
-    public ListenableFuture<JobStatus<Ticket>> createTicketsAsync(List<Ticket> tickets) {
+    public ListenableFuture<JobStatus> createTicketsAsync(List<Ticket> tickets) {
         return submit(req("POST", cnst("/tickets/create_many.json"), JSON, json(
-                Collections.singletonMap("tickets", tickets))), handleJobStatus(Ticket.class));
+                Collections.singletonMap("tickets", tickets))), handleJobStatus());
     }
 
     public Ticket updateTicket(Ticket ticket) {
@@ -352,17 +354,17 @@ public class Zendesk implements Closeable {
                 handle(Ticket.class, "ticket")));
     }
 
-    public JobStatus<Ticket> updateTickets(Ticket... tickets) {
+    public JobStatus updateTickets(Ticket... tickets) {
         return updateTickets(Arrays.asList(tickets));
     }
 
-    public JobStatus<Ticket> updateTickets(List<Ticket> tickets) {
+    public JobStatus updateTickets(List<Ticket> tickets) {
         return complete(updateTicketsAsync(tickets));
     }
 
-    public ListenableFuture<JobStatus<Ticket>> updateTicketsAsync(List<Ticket> tickets) {
+    public ListenableFuture<JobStatus> updateTicketsAsync(List<Ticket> tickets) {
         return submit(req("PUT", cnst("/tickets/update_many.json"), JSON, json(
-                Collections.singletonMap("tickets", tickets))), handleJobStatus(Ticket.class));
+                Collections.singletonMap("tickets", tickets))), handleJobStatus());
     }
 
     public void markTicketAsSpam(Ticket ticket) {
@@ -380,11 +382,10 @@ public class Zendesk implements Closeable {
     }
 
     public JobStatus permanentlyDeleteTickets(long id, long... ids) {
-
         return complete(
                 submit(
                         req("DELETE", tmpl("/deleted_tickets/destroy_many.json{?ids}").set("ids", idArray(id, ids))),
-                        handleJobStatus(JobStatus.class))
+                        handleJobStatus())
         );
     }
 
@@ -817,17 +818,17 @@ public class Zendesk implements Closeable {
                 Collections.singletonMap("user", user))), handle(User.class, "user")));
     }
 
-    public JobStatus<User> createUsers(User... users) {
+    public JobStatus createUsers(User... users) {
         return createUsers(Arrays.asList(users));
     }
 
-    public JobStatus<User> createUsers(List<User> users) {
+    public JobStatus createUsers(List<User> users) {
         return complete(createUsersAsync(users));
     }
 
-    public ListenableFuture<JobStatus<User>> createUsersAsync(List<User> users) {
+    public ListenableFuture<JobStatus> createUsersAsync(List<User> users) {
         return submit(req("POST", cnst("/users/create_many.json"), JSON, json(
-                Collections.singletonMap("users", users))), handleJobStatus(User.class));
+                Collections.singletonMap("users", users))), handleJobStatus());
     }
 
     public User createOrUpdateUser(User user) {
@@ -835,17 +836,17 @@ public class Zendesk implements Closeable {
                 Collections.singletonMap("user", user))), handle(User.class, "user")));
     }
 
-    public JobStatus<User> createOrUpdateUsers(User... users) {
+    public JobStatus createOrUpdateUsers(User... users) {
         return createOrUpdateUsers(Arrays.asList(users));
     }
 
-    public JobStatus<User> createOrUpdateUsers(List<User> users) {
+    public JobStatus createOrUpdateUsers(List<User> users) {
         return complete(createOrUpdateUsersAsync(users));
     }
 
-    public ListenableFuture<JobStatus<User>> createOrUpdateUsersAsync(List<User> users) {
+    public ListenableFuture<JobStatus> createOrUpdateUsersAsync(List<User> users) {
         return submit(req("POST", cnst("/users/create_or_update_many.json"), JSON, json(
-            Collections.singletonMap("users", users))), handleJobStatus(User.class));
+                Collections.singletonMap("users", users))), handleJobStatus());
     }
 
     public User updateUser(User user) {
@@ -854,17 +855,17 @@ public class Zendesk implements Closeable {
                 Collections.singletonMap("user", user))), handle(User.class, "user")));
     }
 
-    public JobStatus<User> updateUsers(User... users) {
+    public JobStatus updateUsers(User... users) {
         return updateUsers(Arrays.asList(users));
     }
 
-    public JobStatus<User> updateUsers(List<User> users) {
+    public JobStatus updateUsers(List<User> users) {
         return complete(updateUsersAsync(users));
     }
 
-    public ListenableFuture<JobStatus<User>> updateUsersAsync(List<User> users) {
+    public ListenableFuture<JobStatus> updateUsersAsync(List<User> users) {
         return submit(req("PUT", cnst("/users/update_many.json"), JSON, json(
-                Collections.singletonMap("users", users))), handleJobStatus(User.class));
+                Collections.singletonMap("users", users))), handleJobStatus());
     }
 
     public void deleteUser(User user) {
@@ -1195,7 +1196,7 @@ public class Zendesk implements Closeable {
                 Collections.singletonMap("organization", organization))), handle(Organization.class, "organization")));
     }
 
-    public JobStatus<Organization> createOrganizations(Organization... organizations) {
+    public JobStatus createOrganizations(Organization... organizations) {
         return createOrganizations(Arrays.asList(organizations));
     }
 
@@ -1203,9 +1204,9 @@ public class Zendesk implements Closeable {
         return complete(createOrganizationsAsync(organizations));
     }
 
-    public ListenableFuture<JobStatus<Organization>> createOrganizationsAsync(List<Organization> organizations) {
+    public ListenableFuture<JobStatus> createOrganizationsAsync(List<Organization> organizations) {
         return submit(req("POST", cnst("/organizations/create_many.json"), JSON, json(
-                Collections.singletonMap("organizations", organizations))), handleJobStatus(Organization.class));
+                Collections.singletonMap("organizations", organizations))), handleJobStatus());
     }
 
     public Organization updateOrganization(Organization organization) {
@@ -1214,7 +1215,7 @@ public class Zendesk implements Closeable {
                 Collections.singletonMap("organization", organization))), handle(Organization.class, "organization")));
     }
 
-    public JobStatus<Organization> updateOrganizations(Organization... organizations) {
+    public JobStatus updateOrganizations(Organization... organizations) {
         return updateOrganizations(Arrays.asList(organizations));
     }
 
@@ -1222,9 +1223,9 @@ public class Zendesk implements Closeable {
         return complete(updateOrganizationsAsync(organizations));
     }
 
-    public ListenableFuture<JobStatus<Organization>> updateOrganizationsAsync(List<Organization> organizations) {
+    public ListenableFuture<JobStatus> updateOrganizationsAsync(List<Organization> organizations) {
         return submit(req("PUT", cnst("/organizations/update_many.json"), JSON, json(
-                Collections.singletonMap("organizations", organizations))), handleJobStatus(Organization.class));
+                Collections.singletonMap("organizations", organizations))), handleJobStatus());
     }
 
     public void deleteOrganization(Organization organization) {
@@ -1283,7 +1284,7 @@ public class Zendesk implements Closeable {
     /**
      * https://developer.zendesk.com/rest_api/docs/support/organization_memberships#create-many-memberships
      */
-    public JobStatus<OrganizationMembership> createOrganizationMemberships(OrganizationMembership... organizationMemberships) {
+    public JobStatus createOrganizationMemberships(OrganizationMembership... organizationMemberships) {
         return createOrganizationMemberships(Arrays.asList(organizationMemberships));
     }
 
@@ -1297,9 +1298,10 @@ public class Zendesk implements Closeable {
     /**
      * https://developer.zendesk.com/rest_api/docs/support/organization_memberships#create-many-memberships
      */
-    public ListenableFuture<JobStatus<OrganizationMembership>> createOrganizationMembershipsAsync(List<OrganizationMembership> organizationMemberships) {
+    public ListenableFuture<JobStatus> createOrganizationMembershipsAsync(
+            List<OrganizationMembership> organizationMemberships) {
         return submit(req("POST", cnst("/organization_memberships/create_many.json"), JSON, json(
-                Collections.singletonMap("organization_memberships", organizationMemberships))), handleJobStatus(OrganizationMembership.class));
+                Collections.singletonMap("organization_memberships", organizationMemberships))), handleJobStatus());
     }
 
     public void deleteOrganizationMembership(long id) {
@@ -2413,17 +2415,16 @@ public class Zendesk implements Closeable {
         return new BasicAsyncCompletionHandler<>(clazz, name, typeParams);
     }
 
-    protected <T> ZendeskAsyncCompletionHandler<JobStatus<T>> handleJobStatus(final Class<T> resultClass) {
-        return new BasicAsyncCompletionHandler<JobStatus<T>>(JobStatus.class, "job_status", resultClass) {
+    protected ZendeskAsyncCompletionHandler<JobStatus> handleJobStatus() {
+        return new BasicAsyncCompletionHandler<JobStatus>(JobStatus.class, "job_status") {
             @Override
-            public JobStatus<T> onCompleted(Response response) throws Exception {
-                JobStatus<T> result = super.onCompleted(response);
+            public JobStatus onCompleted(Response response) throws Exception {
+                JobStatus result = super.onCompleted(response);
                 if (result == null) {
                     // null is when we receive a 404 response.
                     // For an async job we trigger an error
                     throw new ZendeskResponseException(response);
                 }
-                result.setResultsClass(resultClass);
                 return result;
             }
         };

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -1290,6 +1290,14 @@ public class Zendesk implements Closeable {
         complete(submit(req("DELETE", tmpl("/organization_memberships/{id}.json").set("id", id)), handleStatus()));
     }
 
+    /**
+     * https://developer.zendesk.com/rest_api/docs/support/organization_memberships#bulk-delete-memberships
+     */
+    public void deleteOrganizationMemberships(long id, long... ids) {
+        complete(submit(req("DELETE", tmpl("/organization_memberships/destroy_many.json{?ids}").set("ids", idArray(id, ids))),
+                handleStatus()));
+    }
+
     public Iterable<Group> getGroups() {
         return new PagedIterable<>(cnst("/groups.json"),
                 handleList(Group.class, "groups"));

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -27,6 +27,7 @@ import org.zendesk.client.v2.model.Automation;
 import org.zendesk.client.v2.model.Brand;
 import org.zendesk.client.v2.model.Comment;
 import org.zendesk.client.v2.model.ComplianceDeletionStatus;
+import org.zendesk.client.v2.model.DeletedTicket;
 import org.zendesk.client.v2.model.Field;
 import org.zendesk.client.v2.model.Forum;
 import org.zendesk.client.v2.model.Group;
@@ -280,6 +281,23 @@ public class Zendesk implements Closeable {
     public JobStatus permanentlyDeleteTicket(Ticket ticket) {
         checkHasId(ticket);
         return permanentlyDeleteTicket(ticket.getId());
+    }
+
+    /**
+     * https://developer.zendesk.com/rest_api/docs/support/tickets#list-deleted-tickets
+     */
+    public Iterable<DeletedTicket> getDeletedTickets() {
+        return new PagedIterable<>(cnst("/deleted_tickets.json"), handleList(DeletedTicket.class, "deleted_tickets"));
+    }
+
+    /**
+     * https://developer.zendesk.com/rest_api/docs/support/tickets#list-deleted-tickets
+     */
+    public Iterable<DeletedTicket> getDeletedTickets(String sortBy, SortOrder sortOrder) {
+        return new PagedIterable<>(tmpl("/deleted_tickets.json?sort_by={sortBy}&sort_order={sortOrder}")
+                .set("sortBy", sortBy)
+                .set("sortOrder", sortOrder.getQueryParameter()),
+                handleList(DeletedTicket.class, "deleted_tickets"));
     }
 
     public void deleteTicket(Ticket ticket) {

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -363,7 +363,6 @@ public class Zendesk implements Closeable {
     }
 
     public JobStatus permanentlyDeleteTickets(long id, long... ids) {
-        deleteTickets(id, ids);
 
         return complete(
                 submit(

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -2896,6 +2896,7 @@ public class Zendesk implements Closeable {
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         mapper.setDateFormat(new StdDateFormat());
+        mapper.enable(DeserializationFeature.USE_LONG_FOR_INTS);
         return mapper;
     }
 

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -838,6 +838,19 @@ public class Zendesk implements Closeable {
                 Collections.singletonMap("user", user))), handle(User.class, "user")));
     }
 
+    public JobStatus<User> updateUsers(User... users) {
+        return updateUsers(Arrays.asList(users));
+    }
+
+    public JobStatus<User> updateUsers(List<User> users) {
+        return complete(updateUsersAsync(users));
+    }
+
+    public ListenableFuture<JobStatus<User>> updateUsersAsync(List<User> users) {
+        return submit(req("PUT", cnst("/users/update_many.json"), JSON, json(
+                Collections.singletonMap("users", users))), handleJobStatus(User.class));
+    }
+
     public void deleteUser(User user) {
         checkHasId(user);
         deleteUser(user.getId());

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -335,6 +335,14 @@ public class Zendesk implements Closeable {
                 handle(Ticket.class, "ticket")));
     }
 
+    public JobStatus<Ticket> updateTickets(Ticket... tickets) {
+        return updateTickets(Arrays.asList(tickets));
+    }
+
+    public JobStatus<Ticket> updateTickets(List<Ticket> tickets) {
+        return complete(updateTicketsAsync(tickets));
+    }
+
     public ListenableFuture<JobStatus<Ticket>> updateTicketsAsync(List<Ticket> tickets) {
         return submit(req("PUT", cnst("/tickets/update_many.json"), JSON, json(
                 Collections.singletonMap("tickets", tickets))), handleJobStatus(Ticket.class));

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -811,6 +811,19 @@ public class Zendesk implements Closeable {
                 Collections.singletonMap("users", users))), handleJobStatus(User.class));
     }
 
+    public JobStatus<User> createOrUpdateUsers(User... users) {
+        return createOrUpdateUsers(Arrays.asList(users));
+    }
+
+    public JobStatus<User> createOrUpdateUsers(List<User> users) {
+        return complete(createOrUpdateUsersAsync(users));
+    }
+
+    public ListenableFuture<JobStatus<User>> createOrUpdateUsersAsync(List<User> users) {
+        return submit(req("POST", cnst("/users/create_or_update_many.json"), JSON, json(
+            Collections.singletonMap("users", users))), handleJobStatus(User.class));
+    }
+
     public User updateUser(User user) {
         checkHasId(user);
         return complete(submit(req("PUT", tmpl("/users/{id}.json").set("id", user.getId()), JSON, json(

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -1198,6 +1198,19 @@ public class Zendesk implements Closeable {
                 Collections.singletonMap("organization", organization))), handle(Organization.class, "organization")));
     }
 
+    public JobStatus<Organization> updateOrganizations(Organization... organizations) {
+        return updateOrganizations(Arrays.asList(organizations));
+    }
+
+    public JobStatus updateOrganizations(List<Organization> organizations) {
+        return complete(updateOrganizationsAsync(organizations));
+    }
+
+    public ListenableFuture<JobStatus<Organization>> updateOrganizationsAsync(List<Organization> organizations) {
+        return submit(req("PUT", cnst("/organizations/update_many.json"), JSON, json(
+                Collections.singletonMap("organizations", organizations))), handleJobStatus(Organization.class));
+    }
+
     public void deleteOrganization(Organization organization) {
         checkHasId(organization);
         deleteOrganization(organization.getId());

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -801,14 +801,14 @@ public class Zendesk implements Closeable {
         return complete(createUsersAsync(users));
     }
 
-    public User createOrUpdateUser(User user) {
-        return complete(submit(req("POST", cnst("/users/create_or_update.json"), JSON, json(
-                Collections.singletonMap("user", user))), handle(User.class, "user")));
-    }
-
     public ListenableFuture<JobStatus<User>> createUsersAsync(List<User> users) {
         return submit(req("POST", cnst("/users/create_many.json"), JSON, json(
                 Collections.singletonMap("users", users))), handleJobStatus(User.class));
+    }
+
+    public User createOrUpdateUser(User user) {
+        return complete(submit(req("POST", cnst("/users/create_or_update.json"), JSON, json(
+                Collections.singletonMap("user", user))), handle(User.class, "user")));
     }
 
     public JobStatus<User> createOrUpdateUsers(User... users) {

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -310,7 +310,6 @@ public class Zendesk implements Closeable {
     }
 
     public JobStatus permanentlyDeleteTicket(long id) {
-        deleteTicket(id);
         return complete(submit(
                 req("DELETE", tmpl("/deleted_tickets/{id}.json").set("id", id)),
                 handleJobStatus(JobStatus.class))

--- a/src/main/java/org/zendesk/client/v2/Zendesk.java
+++ b/src/main/java/org/zendesk/client/v2/Zendesk.java
@@ -2402,6 +2402,11 @@ public class Zendesk implements Closeable {
             @Override
             public JobStatus<T> onCompleted(Response response) throws Exception {
                 JobStatus<T> result = super.onCompleted(response);
+                if (result == null) {
+                    // null is when we receive a 404 response.
+                    // For an async job we trigger an error
+                    throw new ZendeskResponseException(response);
+                }
                 result.setResultsClass(resultClass);
                 return result;
             }

--- a/src/main/java/org/zendesk/client/v2/model/DeletedTicket.java
+++ b/src/main/java/org/zendesk/client/v2/model/DeletedTicket.java
@@ -1,0 +1,136 @@
+package org.zendesk.client.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DeletedTicket implements Serializable {
+    private static final long serialVersionUID = -1245555299753747844L;
+
+    protected Long id;
+    protected String subject;
+    protected String description;
+    protected Actor actor;
+    protected Status previousState;
+    protected Date deletedAt;
+
+    public DeletedTicket() {
+    }
+
+    public DeletedTicket(Long id, String subject, String description, Actor actor,
+                         Status previousState, Date deletedAt) {
+        this.id = id;
+        this.subject = subject;
+        this.description = description;
+        this.actor = actor;
+        this.previousState = previousState;
+        this.deletedAt = deletedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Actor getActor() {
+        return actor;
+    }
+
+    public void setActor(Actor actor) {
+        this.actor = actor;
+    }
+
+    @JsonProperty("previous_state")
+    public Status getPreviousState() {
+        return previousState;
+    }
+
+    public void setPreviousState(Status previousState) {
+        this.previousState = previousState;
+    }
+
+    @JsonProperty("deleted_at")
+    public Date getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(Date deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "DeletedTicket{" +
+                "id=" + id +
+                ", subject='" + subject + '\'' +
+                ", description='" + description + '\'' +
+                ", actor=" + actor +
+                ", previousState=" + previousState +
+                ", deletedAt=" + deletedAt +
+                '}';
+    }
+
+    public static class Actor implements Serializable {
+        private static final long serialVersionUID = 6945229807147073769L;
+        private Long id;
+        private String name;
+
+        public Actor() {
+        }
+
+        public Actor(Long id) {
+            this.id = id;
+        }
+
+        public Actor(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return "Actor" +
+                    "{id=" + id +
+                    ", name='" + name + '\'' +
+                    '}';
+        }
+    }
+}

--- a/src/main/java/org/zendesk/client/v2/model/JobResult.java
+++ b/src/main/java/org/zendesk/client/v2/model/JobResult.java
@@ -1,0 +1,95 @@
+package org.zendesk.client.v2.model;
+
+import java.io.Serializable;
+import java.util.HashMap;
+
+/**
+ * https://developer.zendesk.com/rest_api/docs/support/job_statuses#results
+ * <p>
+ * Result entries have various properties. There is no clear description thus let's use a generic Map
+ * Only the "id" of the object in Zendesk (Always a Long) seems to be always present.
+ * We define few others helpers.
+ */
+public class JobResult extends HashMap<String, Object> implements Serializable {
+
+    /**
+     * The account ID
+     */
+    public static final String ACCOUNT_ID = "account_id";
+    /**
+     * the action the job attempted
+     */
+    public static final String ACTION = "action";
+    /**
+     * The details about the error
+     */
+    public static final String DETAILS = "details";
+    /**
+     * The user email
+     */
+    public static final String EMAIL = "email";
+    /**
+     * An error code
+     */
+    public static final String ERROR = "error";
+    /**
+     * The user external ID
+     */
+    public static final String EXTERNAL_ID = "external_id";
+    /**
+     * the id of the resource created or updated
+     */
+    public static final String ID = "id";
+    /**
+     * the index number of the result
+     */
+    public static final String INDEX = "index";
+    /**
+     * the status of the action
+     */
+    public static final String STATUS = "status";
+    /**
+     * whether the action was successful or not
+     */
+    public static final String SUCCESS = "success";
+
+    public Long getAccountId() {
+        return (Long) get(ACCOUNT_ID);
+    }
+
+    public String getAction() {
+        return (String) get(ACTION);
+    }
+
+    public String getDetails() {
+        return (String) get(DETAILS);
+    }
+
+    public String getEmail() {
+        return (String) get(EMAIL);
+    }
+
+    public String getError() {
+        return (String) get(ERROR);
+    }
+
+    public String getExternalId() {
+        return (String) get(EXTERNAL_ID);
+    }
+
+    public Long getId() {
+        return (Long) get(ID);
+    }
+
+    public Long getIndex() {
+        return (Long) get(INDEX);
+    }
+
+    public String getStatus() {
+        return (String) get(STATUS);
+    }
+
+    public Boolean getSuccess() {
+        return (Boolean) get(SUCCESS);
+    }
+}

--- a/src/main/java/org/zendesk/client/v2/model/JobStatus.java
+++ b/src/main/java/org/zendesk/client/v2/model/JobStatus.java
@@ -1,9 +1,11 @@
 package org.zendesk.client.v2.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.io.Serializable;
 import java.util.List;
 
-public class JobStatus<T> implements Serializable {
+public class JobStatus implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -13,8 +15,7 @@ public class JobStatus<T> implements Serializable {
     private Integer progress;
     private JobStatusEnum status;
     private String message;
-    private List<T> results;
-    private Class<T> resultsClass;
+    private List<JobResult> results;
 
     public String getId() {
         return id;
@@ -64,20 +65,13 @@ public class JobStatus<T> implements Serializable {
         this.message = message;
     }
 
-    public List<T> getResults() {
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    public List<JobResult> getResults() {
         return results;
     }
 
-    public void setResults(List<T> results) {
+    public void setResults(List<JobResult> results) {
         this.results = results;
-    }
-
-    public Class<T> getResultsClass() {
-        return resultsClass;
-    }
-
-    public void setResultsClass(Class<T> resultsClass) {
-        this.resultsClass = resultsClass;
     }
 
     @Override

--- a/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
+++ b/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
@@ -1,10 +1,13 @@
 package org.zendesk.client.v2;
 
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsCollectionContaining;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zendesk.client.v2.model.AgentRole;
@@ -13,11 +16,14 @@ import org.zendesk.client.v2.model.Brand;
 import org.zendesk.client.v2.model.Collaborator;
 import org.zendesk.client.v2.model.Comment;
 import org.zendesk.client.v2.model.ComplianceDeletionStatus;
+import org.zendesk.client.v2.model.DeletedTicket;
 import org.zendesk.client.v2.model.Field;
 import org.zendesk.client.v2.model.Group;
 import org.zendesk.client.v2.model.Identity;
+import org.zendesk.client.v2.model.JobResult;
 import org.zendesk.client.v2.model.JobStatus;
 import org.zendesk.client.v2.model.Organization;
+import org.zendesk.client.v2.model.OrganizationMembership;
 import org.zendesk.client.v2.model.Priority;
 import org.zendesk.client.v2.model.Request;
 import org.zendesk.client.v2.model.SortOrder;
@@ -43,26 +49,36 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 
@@ -77,10 +93,19 @@ public class RealSmokeTest {
     // TODO: Find a better way to manage our test environment (this is the PUBLIC_FORM_ID of the cloudbees org)
     private static final long CLOUDBEES_ORGANIZATION_ID = 360507899132L;
     private static final long PUBLIC_FORM_ID = 360000434032L;
+    private static final Random RANDOM = new Random();
+    private static final String TICKET_COMMENT1 = "Please ignore this ticket";
+    private static final String TICKET_COMMENT2 = "Yes ignore this ticket";
 
     private static Properties config;
 
     private Zendesk instance;
+
+    /**
+     * Global timeout applied on each test to avoid to wait forever if something goes wrong with the remote server
+     */
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(30);
 
     @BeforeClass
     public static void loadConfig() {
@@ -293,26 +318,23 @@ public class RealSmokeTest {
                 .build();
         Ticket t = instance.getTicket(1);
         assertThat(t, notNullValue());
-        System.out.println(t);
     }
 
     @Test
     public void createAnonymousClient() {
         instance = new Zendesk.Builder(config.getProperty("url"))
                 .build();
+        assertThat("An instance is created", instance, Matchers.notNullValue());
     }
 
     @Test
     public void createDeleteTicket() throws Exception {
         createClientWithTokenOrPassword();
-        assumeThat("Must have a requester email", config.getProperty("requester.email"), notNullValue());
-        Ticket t = new Ticket(
-                new Ticket.Requester(config.getProperty("requester.name"), config.getProperty("requester.email")),
-                "This is a test", new Comment("Please ignore this ticket"));
-        t.setCollaborators(Arrays.asList(new Collaborator("Bob Example", "bob@example.org"), new Collaborator("Alice Example", "alice@example.org")));
+
+        Ticket t = newTestTicket();
         Ticket ticket = instance.createTicket(t);
-        System.out.println(ticket.getId() + " -> " + ticket.getUrl());
         assertThat(ticket.getId(), notNullValue());
+
         try {
             Ticket t2 = instance.getTicket(ticket.getId());
             assertThat(t2, notNullValue());
@@ -320,7 +342,8 @@ public class RealSmokeTest {
 
             List<User> ticketCollaborators = instance.getTicketCollaborators(ticket.getId());
             assertThat("Collaborators", ticketCollaborators.size(), is(2));
-            assertThat("First Collaborator", ticketCollaborators.get(0).getEmail(), anyOf(is("alice@example.org"), is("bob@example.org")));
+            assertThat("First Collaborator", ticketCollaborators.get(0).getEmail(),
+                    anyOf(is("alice@example.org"), is("bob@example.org")));
         } finally {
             instance.deleteTicket(ticket.getId());
         }
@@ -335,13 +358,8 @@ public class RealSmokeTest {
     @Test
     public void createPermanentlyDeleteTicket() throws Exception {
         createClientWithTokenOrPassword();
-        assumeThat("Must have a requester email", config.getProperty("requester.email"), notNullValue());
-        Ticket t = new Ticket(
-                new Ticket.Requester(config.getProperty("requester.name"), config.getProperty("requester.email")),
-                "This is a test", new Comment("Please ignore this ticket"));
-        t.setCollaborators(Arrays.asList(new Collaborator("Bob Example", "bob@example.org"), new Collaborator("Alice Example", "alice@example.org")));
+        Ticket t = newTestTicket();
         Ticket ticket = instance.createTicket(t);
-        System.out.println(ticket.getId() + " -> " + ticket.getUrl());
         assertThat(ticket.getId(), notNullValue());
 
         try {
@@ -349,66 +367,61 @@ public class RealSmokeTest {
             assertThat(t2, notNullValue());
             assertThat(t2.getId(), is(ticket.getId()));
         } finally {
-            instance.permanentlyDeleteTicket(ticket.getId());
+            instance.deleteTicket(ticket.getId());
+            waitTicketDeleted(ticket.getId());
+            waitJobCompletion(instance.permanentlyDeleteTicket(ticket.getId()));
         }
         assertThat(instance.getTicket(ticket.getId()), nullValue());
     }
 
     @Test
-    @Ignore("This test isn't stable in the CI env. Not sure why, it's working locally.")
-    // TODO: Fix this test
     public void createPermanentlyDeleteTickets() throws Exception {
         createClientWithTokenOrPassword();
-        assumeThat("Must have a requester email", config.getProperty("requester.email"), notNullValue());
-        Ticket t = new Ticket(
-                new Ticket.Requester(config.getProperty("requester.name"), config.getProperty("requester.email")),
-                "This is a test", new Comment("Please ignore this ticket"));
-        t.setCollaborators(Arrays.asList(new Collaborator("Bob Example", "bob@example.org"), new Collaborator("Alice Example", "alice@example.org")));
-        Ticket t2 = new Ticket(
-                new Ticket.Requester(config.getProperty("requester.name"), config.getProperty("requester.email")),
-                "This is a test_2", new Comment("Please ignore this ticket_2"));
-        t2.setCollaborators(Arrays.asList(new Collaborator("Bob Example_2", "bob@example.org"), new Collaborator("Alice Example_2", "alice@example.org")));
-        Ticket ticket = instance.createTicket(t);
-        Ticket ticket2 = instance.createTicket(t2);
-        System.out.println(ticket.getId() + " -> " + ticket.getUrl());
-        System.out.println(ticket2.getId() + " -> " + ticket2.getUrl());
-        assertThat(ticket.getId(), notNullValue());
-        assertThat(ticket2.getId(), notNullValue());
-
-        try {
-            Ticket t3 = instance.getTicket(ticket.getId());
-            assertThat(t3, notNullValue());
-            assertThat(t3.getId(), is(ticket.getId()));
-
-            Ticket t4 = instance.getTicket(ticket2.getId());
-            assertThat(t4, notNullValue());
-            assertThat(t4.getId(), is(ticket2.getId()));
-        } finally {
-            instance.permanentlyDeleteTickets(ticket.getId(), ticket2.getId());
-        }
-        assertThat(instance.getTicket(ticket.getId()), nullValue());
-        assertThat(instance.getTicket(ticket2.getId()), nullValue());
+        // given
+        // We create some tickets
+        final List<Ticket> tickets = createTestTicketsInZendesk();
+        final Long[] ticketsIds = tickets.stream().map(Ticket::getId).toArray(Long[]::new);
+        // when
+        // We soft delete them
+        instance.deleteTickets(firstElement(ticketsIds), otherElements(ticketsIds));
+        waitTicketsDeleted(ticketsIds);
+        // We permanently delete them
+        JobStatus jobStatus =
+                waitJobCompletion(
+                        instance.permanentlyDeleteTickets(firstElement(ticketsIds), otherElements(ticketsIds)));
+        // then
+        assertThat("Job is completed", jobStatus.getStatus(), is(JobStatus.JobStatusEnum.completed));
+        jobStatus.getResults().forEach(jobResult -> {
+            assertThat("The job result has no account_id entry", jobResult.getAccountId(), nullValue());
+            assertThat("The job result has no action entry", jobResult.getAction(), nullValue());
+            assertThat("The job result has no details entry", jobResult.getDetails(), nullValue());
+            assertThat("The job result has no email entry", jobResult.getEmail(), nullValue());
+            assertThat("The job result has no error entry", jobResult.getError(), nullValue());
+            assertThat("The job result has no external_id entry", jobResult.getExternalId(), nullValue());
+            assertThat("The job result has no id entry", jobResult.getId(), nullValue());
+            assertThat("The job result has no index entry", jobResult.getIndex(), nullValue());
+            assertThat("The job result has no status entry", jobResult.getStatus(), nullValue());
+            assertThat("The job result has a success entry", jobResult.getSuccess(), is(TRUE));
+        });
+        assumeThat("We cannot find them anymore",
+                instance.getTickets(firstElement(ticketsIds), otherElements(ticketsIds)), empty());
     }
 
     @Test
     public void createSolveTickets() throws Exception {
         createClientWithTokenOrPassword();
-        assumeThat("Must have a requester email", config.getProperty("requester.email"), notNullValue());
         Ticket ticket;
         long firstId = Long.MAX_VALUE;
         do {
-            Ticket t = new Ticket(
-                    new Ticket.Requester(config.getProperty("requester.name"), config.getProperty("requester.email")),
-                    "This is a test " + UUID.randomUUID().toString(), new Comment("Please ignore this ticket"));
+            Ticket t = newTestTicket();
             ticket = instance.createTicket(t);
-            System.out.println(ticket.getId() + " -> " + ticket.getUrl());
             assertThat(ticket.getId(), notNullValue());
-                Ticket t2 = instance.getTicket(ticket.getId());
-                assertThat(t2, notNullValue());
-                assertThat(t2.getId(), is(ticket.getId()));
-                t2.setAssigneeId(instance.getCurrentUser().getId());
-                t2.setStatus(Status.CLOSED);
-                instance.updateTicket(t2);
+            Ticket t2 = instance.getTicket(ticket.getId());
+            assertThat(t2, notNullValue());
+            assertThat(t2.getId(), is(ticket.getId()));
+            t2.setAssigneeId(instance.getCurrentUser().getId());
+            t2.setStatus(Status.CLOSED);
+            instance.updateTicket(t2);
             assertThat(ticket.getSubject(), is(t.getSubject()));
             assertThat(ticket.getRequester(), nullValue());
             assertThat(ticket.getRequesterId(), notNullValue());
@@ -419,44 +432,94 @@ public class RealSmokeTest {
     }
 
     @Test
-    public void testUpdateTickets() throws Exception {
+    public void createTickets() throws Exception {
+        // given
         createClientWithTokenOrPassword();
-        Ticket t = new Ticket(
-                new Ticket.Requester(config.getProperty("requester.name"), config.getProperty("requester.email")),
-                "This is a test " + UUID.randomUUID().toString(), new Comment("Please ignore this ticket"));
-        Ticket ticket1 = instance.createTicket(t);
-        Ticket t2 = new Ticket(
-                new Ticket.Requester(config.getProperty("requester.name"), config.getProperty("requester.email")),
-                "This is a test " + UUID.randomUUID().toString(), new Comment("Please ignore this ticket"));
-        Ticket ticket2 = instance.createTicket(t2);
-        ticket1.setPriority(Priority.HIGH);
-        ticket2.setPriority(Priority.LOW);
-        ticket1.setStatus(Status.SOLVED);
-        ticket2.setStatus(Status.SOLVED);
+        final Ticket[] ticketsToCreate = newTestTickets();
 
-        JobStatus<Ticket> jobstatus = instance.updateTicketsAsync(Arrays.asList(ticket1, ticket2)).toCompletableFuture().join();
-        assertThat(jobstatus.getStatus(), is(JobStatus.JobStatusEnum.queued));
-        //TODO: uncomment the rest of this test once issue #98 is resolved: https://github.com/cloudbees/zendesk-java-client/issues/98
-//        Instant startUpdateAt = Instant.now();
-//        while (instance.getJobStatus(jobstatus).getStatus() != JobStatus.JobStatusEnum.completed
-//                && startUpdateAt.plusSeconds(10).isAfter(Instant.now())) {
-//            Thread.sleep(100);
-//        }
-//        JobStatus<Ticket> completedJobStatus = instance.getJobStatus(jobstatus);
-//        assertThat(completedJobStatus.getStatus(), is(JobStatus.JobStatusEnum.completed));
-//        assertNotNull(jobstatus.getResults());
-//        assertThat(jobstatus.getResults().size(), is(2));
-//        jobstatus.getResults().forEach(ticket -> {
-//            if (ticket.getId().equals(ticket1.getId())) {
-//                assertThat(ticket.getPriority(), is(Priority.HIGH));
-//                assertThat(ticket.getStatus(), is(Status.SOLVED));
-//            } else if (ticket.getId().equals(ticket2.getId())) {
-//                assertThat(ticket.getPriority(), is(Priority.LOW));
-//                assertThat(ticket.getStatus(), is(Status.SOLVED));
-//            } else {
-//                fail("Received a different ticket back in response: " + ticket.getId());
-//            }
-//        });
+        // when
+
+        final JobStatus status = waitJobCompletion(instance.createTickets(ticketsToCreate));
+
+        // then
+        final Long[] createdTicketsIds =
+                status.getResults().stream().map(JobResult::getId).toArray(Long[]::new);
+        try {
+            final List<Ticket> createdTickets =
+                    instance.getTickets(firstElement(createdTicketsIds), otherElements(createdTicketsIds));
+
+            assertThat("We have the same number of tickets", status.getResults(), hasSize(ticketsToCreate.length));
+
+            status.getResults().forEach(jobResult -> {
+                assertThat("The job result has an account_id entry", jobResult.getAccountId(), notNullValue());
+                assertThat("The job result has no action entry", jobResult.getAction(), nullValue());
+                assertThat("The job result has no details entry", jobResult.getDetails(), nullValue());
+                assertThat("The job result has no email entry", jobResult.getEmail(), nullValue());
+                assertThat("The job result has no error entry", jobResult.getError(), nullValue());
+                assertThat("The job result has no external_id entry", jobResult.getExternalId(), nullValue());
+                assertThat("The job result has an id entry", jobResult.getId(), notNullValue());
+                assertThat("The job result has an index entry", jobResult.getIndex(), notNullValue());
+                assertThat("The job result has no status entry", jobResult.getStatus(), nullValue());
+                assertThat("The job result has no success entry", jobResult.getSuccess(), nullValue());
+            });
+
+            assertThat("All tickets are created (we verify that all titles are present)",
+                    createdTickets
+                            .stream()
+                            .map(Ticket::getSubject)
+                            .collect(Collectors.toList()),
+                    containsInAnyOrder(
+                            Arrays.stream(ticketsToCreate)
+                                    .map(Ticket::getSubject)
+                                    .toArray()));
+            createdTickets.stream().map(Ticket::getId).forEach(id ->
+                    assertThat("A unique ID must be set", id, notNullValue()));
+        } finally {
+            // cleanup
+            instance.deleteTickets(firstElement(createdTicketsIds), otherElements(createdTicketsIds));
+        }
+    }
+
+    @Test
+    public void updateTickets() throws Exception {
+        createClientWithTokenOrPassword();
+
+        // given
+        // We create some test tickets
+        final List<Ticket> tickets = createTestTicketsInZendesk();
+        final Long[] ticketsIds = tickets.stream().map(Ticket::getId).toArray(Long[]::new);
+
+        try {
+            // when
+            // We update them
+            tickets.forEach(ticket -> {
+                ticket.setPriority(Priority.HIGH);
+                ticket.setStatus(Status.OPEN);
+            });
+            final JobStatus status = waitJobCompletion(instance.updateTickets(tickets));
+
+            // then
+            assertThat("Job is completed", status.getStatus(), is(JobStatus.JobStatusEnum.completed));
+            assertThat("The good number of tickets were processed", status.getTotal(), is(ticketsIds.length));
+            assertThat("We have a result for each ticket", status.getResults(), hasSize(ticketsIds.length));
+            assertThat("Each ticket has a result",
+                    status.getResults().stream().map(JobResult::getId).collect(Collectors.toList()),
+                    containsInAnyOrder(ticketsIds));
+            status.getResults().forEach(jobResult -> {
+                assertThat("The job result has no account_id entry", jobResult.getAccountId(), nullValue());
+                assertThat("The job result has an action entry", jobResult.getAction(), is("update"));
+                assertThat("The job result has no details entry", jobResult.getDetails(), nullValue());
+                assertThat("The job result has no email entry", jobResult.getEmail(), nullValue());
+                assertThat("The job result has no error entry", jobResult.getError(), nullValue());
+                assertThat("The job result has no external_id entry", jobResult.getExternalId(), nullValue());
+                assertThat("The job result has an id entry", jobResult.getId(), notNullValue());
+                assertThat("The job result has no index entry", jobResult.getIndex(), nullValue());
+                assertThat("The job result has a status entry", jobResult.getStatus(), is("Updated"));
+                assertThat("The job result has a success entry", jobResult.getSuccess(), is(TRUE));
+            });
+        } finally {
+            instance.deleteTickets(firstElement(ticketsIds), otherElements(ticketsIds));
+        }
     }
 
     @Test
@@ -476,6 +539,166 @@ public class RealSmokeTest {
         assumeThat("Must have a requester email", requesterEmail, notNullValue());
         for (User user : instance.getSearchResults(User.class, "requester:"+requesterEmail)) {
             assertThat(user.getEmail(), is(requesterEmail));
+        }
+    }
+
+    @Test
+    public void createUsers() throws Exception {
+        // given
+        createClientWithTokenOrPassword();
+        final User[] usersToCreate = newTestUsers();
+
+        // when
+        final JobStatus status = waitJobCompletion(instance.createUsers(usersToCreate));
+
+        // then
+        final Long[] createdUsersIds =
+                status.getResults().stream().map(JobResult::getId).toArray(Long[]::new);
+        try {
+            final List<User> createdUsers =
+                    Arrays.stream(createdUsersIds).map(instance::getUser).collect(Collectors.toList());
+
+            assertThat("We have the same number of users", status.getResults(), hasSize(usersToCreate.length));
+
+            status.getResults().forEach(jobResult -> {
+                assertThat("The job result has no account_id entry", jobResult.getAccountId(), nullValue());
+                assertThat("The job result has no action entry", jobResult.getAction(), nullValue());
+                assertThat("The job result has no details entry", jobResult.getDetails(), nullValue());
+                assertThat("The job result has an email entry", jobResult.getEmail(), notNullValue());
+                assertThat("The job result has no error entry", jobResult.getError(), nullValue());
+                assertThat("The job result has an external_id entry", jobResult.getExternalId(), notNullValue());
+                assertThat("The job result has an id entry", jobResult.getId(), notNullValue());
+                assertThat("The job result has no index entry", jobResult.getIndex(), nullValue());
+                assertThat("The job result has a status entry", jobResult.getStatus(), is("Created"));
+                assertThat("The job result has no success entry", jobResult.getSuccess(), nullValue());
+            });
+
+            assertThat("All users are created (we verify that all names are present)",
+                    createdUsers
+                            .stream()
+                            .map(User::getName)
+                            .collect(Collectors.toList()),
+                    containsInAnyOrder(
+                            Arrays.stream(usersToCreate)
+                                    .map(User::getName)
+                                    .toArray()));
+            createdUsers.stream().map(User::getId).forEach(id ->
+                    assertThat("A unique ID must be set", id, notNullValue()));
+        } finally {
+            // cleanup
+            Arrays.stream(createdUsersIds).forEach(instance::deleteUser);
+        }
+    }
+
+    @Test
+    public void updateUsers() throws Exception {
+        createClientWithTokenOrPassword();
+
+        // given
+        // We create some test users
+        final List<User> users = createTestUsersInZendesk();
+        final Long[] usersIds = users.stream().map(User::getId).toArray(Long[]::new);
+
+        try {
+            // when
+            // We update them
+            users.forEach(user -> user.setNotes("This user was updated"));
+            final JobStatus status = waitJobCompletion(instance.updateUsers(users));
+
+            // then
+            assertThat("Job is completed", status.getStatus(), is(JobStatus.JobStatusEnum.completed));
+            assertThat("The good number of users were processed", status.getTotal(), is(usersIds.length));
+            assertThat("We have a result for each user", status.getResults(), hasSize(usersIds.length));
+            assertThat("Each user has a result",
+                    status.getResults().stream().map(JobResult::getId).collect(Collectors.toList()),
+                    containsInAnyOrder(usersIds));
+            status.getResults().forEach(jobResult -> {
+                assertThat("The job result has no account_id entry", jobResult.getAccountId(), nullValue());
+                assertThat("The job result has an action entry", jobResult.getAction(), is("update"));
+                assertThat("The job result has no details entry", jobResult.getDetails(), nullValue());
+                assertThat("The job result has no email entry", jobResult.getEmail(), nullValue());
+                assertThat("The job result has no error entry", jobResult.getError(), nullValue());
+                assertThat("The job result has no external_id entry", jobResult.getExternalId(), nullValue());
+                assertThat("The job result has an id entry", jobResult.getId(), notNullValue());
+                assertThat("The job result has no index entry", jobResult.getIndex(), nullValue());
+                assertThat("The job result has a status entry", jobResult.getStatus(), is("Updated"));
+                assertThat("The job result has a success entry", jobResult.getSuccess(), is(TRUE));
+            });
+        } finally {
+            // cleanup
+            Arrays.stream(usersIds).forEach(instance::deleteUser);
+        }
+    }
+
+    @Test
+    public void createOrUpdateUsers() throws Exception {
+        createClientWithTokenOrPassword();
+
+        // given
+        // We create some test users
+        final List<User> existingUsers = createTestUsersInZendesk();
+        final Long[] existingUsersIds = existingUsers.stream().map(User::getId).toArray(Long[]::new);
+        // And we add new users
+        final List<User> newUsers = Arrays.asList(newTestUsers());
+        final List<User> allUsers = new ArrayList<>(existingUsers);
+        allUsers.addAll(newUsers);
+        Long[] newUsersIds = null;
+        try {
+            // when
+            // We update them
+            allUsers.forEach(user -> user.setNotes("This user was updated"));
+            final JobStatus status =
+                    waitJobCompletion(instance.createOrUpdateUsers(allUsers));
+
+            // then
+            assertThat("Job is completed", status.getStatus(), is(JobStatus.JobStatusEnum.completed));
+            assertThat("The good number of users were processed", status.getTotal(), is(allUsers.size()));
+            assertThat("We have a result for each user", status.getResults(), hasSize(allUsers.size()));
+            assertThat("Each existing user has a result",
+                    status.getResults()
+                            .stream()
+                            .map(JobResult::getId)
+                            .collect(Collectors.toList()),
+                    hasItems(existingUsersIds));
+            status.getResults().forEach(jobResult -> {
+                assertThat("The job result has no account_id entry", jobResult.getAccountId(), nullValue());
+                assertThat("The job result has an action entry", jobResult.getAction(), nullValue());
+                assertThat("The job result has no details entry", jobResult.getDetails(), nullValue());
+                assertThat("The job result has an email entry", jobResult.getEmail(), notNullValue());
+                assertThat("The job result has no error entry", jobResult.getError(), nullValue());
+                assertThat("The job result has an external_id entry", jobResult.getExternalId(), notNullValue());
+                assertThat("The job result has an id entry", jobResult.getId(), notNullValue());
+                assertThat("The job result has no index entry", jobResult.getIndex(), nullValue());
+                assertThat("The job result has a status entry", jobResult.getStatus(), notNullValue());
+                assertThat("The job result has a success entry", jobResult.getSuccess(), nullValue());
+            });
+            assertThat("Existing users are updated",
+                    status.getResults()
+                            .stream()
+                            .filter(jobResult -> Objects.equals(jobResult.getStatus(), "Updated"))
+                            .map(JobResult::getId)
+                            .collect(Collectors.toList()),
+                    containsInAnyOrder(existingUsersIds)
+            );
+            assertThat("New users are created",
+                    status.getResults()
+                            .stream()
+                            .filter(jobResult -> Objects.equals(jobResult.getStatus(), "Created"))
+                            .map(JobResult::getExternalId)
+                            .collect(Collectors.toList()),
+                    containsInAnyOrder(newUsers.stream().map(User::getExternalId).toArray())
+            );
+            newUsersIds = status.getResults()
+                    .stream()
+                    .filter(jobResult -> Objects.equals(jobResult.getStatus(), "Created"))
+                    .map(JobResult::getId)
+                    .toArray(Long[]::new);
+        } finally {
+            // cleanup
+            Arrays.stream(existingUsersIds).forEach(instance::deleteUser);
+            if (newUsersIds != null) {
+                Arrays.stream(newUsersIds).forEach(instance::deleteUser);
+            }
         }
     }
 
@@ -737,94 +960,160 @@ public class RealSmokeTest {
         instance.deleteOrganization(result);
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void createOrganizations() throws Exception {
+        // given
         createClientWithTokenOrPassword();
+        final Organization[] orgsToCreate = newTestOrganizations();
 
-        // Clean up to avoid conflicts
-        for (Organization t : instance.getOrganizations()) {
-            if ("testorg1".equals(t.getExternalId()) || "testorg2".equals(t.getExternalId())) {
-                instance.deleteOrganization(t);
-            }
-        }
+        // when
+        final JobStatus status = waitJobCompletion(instance.createOrganizations(orgsToCreate));
 
-        Organization org1 = new Organization();
-        org1.setExternalId("testorg1");
-        org1.setName("Test Organization 1");
+        // then
+        final Long[] createdOrgsIds =
+                status.getResults().stream().map(JobResult::getId).toArray(Long[]::new);
+        try {
+            final List<Organization> createdOrgs =
+                    Arrays.stream(createdOrgsIds).map(instance::getOrganization).collect(Collectors.toList());
 
-        Organization org2 = new Organization();
-        org2.setExternalId("testorg2");
-        org2.setName("Test Organization 2");
+            assertThat("We have the same number of organizations", status.getResults(), hasSize(orgsToCreate.length));
 
-        JobStatus<Organization> result = instance.createOrganizations(org1, org2);
-        assertNotNull(result);
-        assertNotNull(result.getId());
-        assertNotNull(result.getStatus());
+            status.getResults().forEach(jobResult -> {
+                assertThat("The job result has no account_id entry", jobResult.getAccountId(), nullValue());
+                assertThat("The job result has no action entry", jobResult.getAction(), nullValue());
+                assertThat("The job result has no details entry", jobResult.getDetails(), nullValue());
+                assertThat("The job result has no email entry", jobResult.getEmail(), nullValue());
+                assertThat("The job result has no error entry", jobResult.getError(), nullValue());
+                assertThat("The job result has no external_id entry", jobResult.getExternalId(), nullValue());
+                assertThat("The job result has an id entry", jobResult.getId(), notNullValue());
+                assertThat("The job result has no index entry", jobResult.getIndex(), nullValue());
+                assertThat("The job result has a status entry", jobResult.getStatus(), is("Created"));
+                assertThat("The job result has no success entry", jobResult.getSuccess(), nullValue());
+            });
 
-        while (result.getStatus() != JobStatus.JobStatusEnum.completed) {
-            result = instance.getJobStatus(result);
-            assertNotNull(result);
-            assertNotNull(result.getId());
-            assertNotNull(result.getStatus());
-        }
-
-        List<Organization> resultOrgs = result.getResults();
-
-        assertEquals(2, resultOrgs.size());
-        for (Organization org : resultOrgs) {
-            assertNotNull(org.getId());
-            instance.deleteOrganization(org);
+            assertThat("All organizations are created (we verify that all names are present)",
+                    createdOrgs
+                            .stream()
+                            .map(Organization::getName)
+                            .collect(Collectors.toList()),
+                    containsInAnyOrder(
+                            Arrays.stream(orgsToCreate)
+                                    .map(Organization::getName)
+                                    .toArray()));
+            createdOrgs.stream().map(Organization::getId).forEach(id ->
+                    assertThat("A unique ID must be set", id, notNullValue()));
+        } finally {
+            // cleanup
+            Arrays.stream(createdOrgsIds).forEach(instance::deleteOrganization);
         }
     }
 
-    @Test(timeout = 10000)
-    public void bulkCreateMultipleJobs() throws Exception {
+    @Test
+    public void updateOrganizations() throws Exception {
         createClientWithTokenOrPassword();
 
-        List<Organization> orgs = new ArrayList<>(4);
-        for (int i = 1; i <= 5; i++) {
-            Organization org = new Organization();
-            org.setExternalId("testorg" + i);
-            org.setName("Test Organization " + i);
-            orgs.add(org);
-        }
+        // given
+        // We create some test organizations
+        final List<Organization> organizations = createTestOrganizationsInZendesk();
+        final Long[] orgsIds = organizations.stream().map(Organization::getId).toArray(Long[]::new);
 
-        // Clean up to avoid conflicts
-        for (Organization t : instance.getOrganizations()) {
-            for (Organization org : orgs) {
-                if (org.getExternalId().equals(t.getExternalId())) {
-                    instance.deleteOrganization(t);
+        try {
+            // when
+            // We update them
+            organizations.forEach(organization -> organization.setNotes("This organization was updated"));
+            final JobStatus status =
+                    waitJobCompletion(instance.updateOrganizations(organizations));
+
+            // then
+            assertThat("Job is completed", status.getStatus(), is(JobStatus.JobStatusEnum.completed));
+            assertThat("The good number of organizations were processed", status.getTotal(), is(orgsIds.length));
+            assertThat("We have a result for each organization", status.getResults(), hasSize(orgsIds.length));
+            assertThat("Each organization has a result",
+                    status.getResults().stream().map(JobResult::getId).collect(Collectors.toList()),
+                    containsInAnyOrder(orgsIds));
+            status.getResults().forEach(jobResult -> {
+                assertThat("The job result has no account_id entry", jobResult.getAccountId(), nullValue());
+                assertThat("The job result has an action entry", jobResult.getAction(), is("update"));
+                assertThat("The job result has no details entry", jobResult.getDetails(), nullValue());
+                assertThat("The job result has no email entry", jobResult.getEmail(), nullValue());
+                assertThat("The job result has no error entry", jobResult.getError(), nullValue());
+                assertThat("The job result has no external_id entry", jobResult.getExternalId(), nullValue());
+                assertThat("The job result has an id entry", jobResult.getId(), notNullValue());
+                assertThat("The job result has no index entry", jobResult.getIndex(), nullValue());
+                assertThat("The job result has a status entry", jobResult.getStatus(), is("Updated"));
+                assertThat("The job result has a success entry", jobResult.getSuccess(), is(TRUE));
+            });
+        } finally {
+            // cleanup
+            Arrays.stream(orgsIds).forEach(instance::deleteOrganization);
+        }
+    }
+
+    @Test
+    public void createOrganizationMemberships() throws Exception {
+        createClientWithTokenOrPassword();
+
+        // given
+        // We create some test organizations
+        final List<Organization> organizations = createTestOrganizationsInZendesk();
+        final Long[] orgsIds = organizations.stream().map(Organization::getId).toArray(Long[]::new);
+        // We create some test users
+        final List<User> users = createTestUsersInZendesk();
+        final Long[] usersIds = users.stream().map(User::getId).toArray(Long[]::new);
+
+        final List<OrganizationMembership> organizationMemberships = new ArrayList<>();
+        // We add all users by default in the first org
+        users.forEach(user -> {
+            OrganizationMembership defaultOrganizationMembership = new OrganizationMembership();
+            defaultOrganizationMembership.setOrganizationId(firstElement(orgsIds));
+            defaultOrganizationMembership.setUserId(user.getId());
+            defaultOrganizationMembership.setDefault(TRUE);
+            organizationMemberships.add(defaultOrganizationMembership);
+        });
+        // We add them in others orgs too
+        Arrays.stream(otherElements(orgsIds)).forEach(orgId -> {
+                    users.forEach(user -> {
+                        OrganizationMembership organizationMembership = new OrganizationMembership();
+                        organizationMembership.setOrganizationId(orgId);
+                        organizationMembership.setUserId(user.getId());
+                        organizationMembership.setDefault(FALSE);
+                        organizationMemberships.add(organizationMembership);
+                    });
                 }
-            }
-        }
+        );
 
+        // when
+        // We create them
+        final JobStatus status =
+                waitJobCompletion(instance.createOrganizationMemberships(organizationMemberships));
 
-        JobStatus result1 = instance.createOrganizations(orgs.subList(0, 2));
-        JobStatus result2 = instance.createOrganizations(orgs.subList(2, 5));
+        // then
+        final Long[] orgMembershipsIds =
+                status.getResults().stream().map(JobResult::getId).toArray(Long[]::new);
 
-        while (result1.getStatus() != JobStatus.JobStatusEnum.completed || result2.getStatus() != JobStatus.JobStatusEnum.completed) {
-            List<JobStatus<HashMap<String, Object>>> results = instance.getJobStatuses(Arrays.asList(result1, result2));
-            result1 = results.get(0);
-            result2 = results.get(1);
-            assertNotNull(result1);
-            assertNotNull(result1.getId());
-            assertNotNull(result2);
-            assertNotNull(result2.getId());
-        }
+        try {
 
-        List<HashMap> resultOrgs1 = result1.getResults();
-        assertEquals(2, resultOrgs1.size());
-        List<HashMap> resultOrgs2 = result2.getResults();
-        assertEquals(3, resultOrgs2.size());
+            assertThat("We have the same number of memberships", status.getResults(),
+                    hasSize(organizationMemberships.size()));
 
-        for (HashMap org : resultOrgs1) {
-            assertNotNull(org.get("id"));
-            instance.deleteOrganization(((Number) org.get("id")).longValue());
-        }
+            status.getResults().forEach(jobResult -> {
+                assertThat("The job result has no account_id entry", jobResult.getAccountId(), nullValue());
+                assertThat("The job result has no action entry", jobResult.getAction(), nullValue());
+                assertThat("The job result has no details entry", jobResult.getDetails(), nullValue());
+                assertThat("The job result has no email entry", jobResult.getEmail(), nullValue());
+                assertThat("The job result has no error entry", jobResult.getError(), nullValue());
+                assertThat("The job result has no external_id entry", jobResult.getExternalId(), nullValue());
+                assertThat("The job result has an id entry", jobResult.getId(), notNullValue());
+                assertThat("The job result has no index entry", jobResult.getIndex(), notNullValue());
+                assertThat("The job result has a status entry", jobResult.getStatus(), nullValue());
+                assertThat("The job result has no success entry", jobResult.getSuccess(), nullValue());
+            });
 
-        for (HashMap org : resultOrgs2) {
-            assertNotNull(org.get("id"));
-            instance.deleteOrganization(((Number) org.get("id")).longValue());
+        } finally {
+            // cleanup
+            Arrays.stream(orgsIds).forEach(instance::deleteOrganization);
+            Arrays.stream(usersIds).forEach(instance::deleteUser);
+            instance.deleteOrganizationMemberships(firstElement(orgMembershipsIds), otherElements(orgMembershipsIds));
         }
     }
 
@@ -1192,20 +1481,18 @@ public class RealSmokeTest {
     public void getTicketCommentsShouldBeAscending() throws Exception {
         createClientWithTokenOrPassword();
 
-        Ticket t = new Ticket(
-              new Ticket.Requester(config.getProperty("requester.name"), config.getProperty("requester.email")),
-              "This is an automated test ticket", new Comment("1"));
+        Ticket t = newTestTicket();
         Ticket ticket = null;
         try {
             ticket = instance.createTicket(t);
-            instance.createComment(ticket.getId(), new Comment("2"));
+            instance.createComment(ticket.getId(), new Comment(TICKET_COMMENT2));
             Iterable<Comment> ticketCommentsIt = instance.getTicketComments(ticket.getId());
             List<Comment> comments = new ArrayList<>();
             ticketCommentsIt.forEach(comments::add);
 
             assertThat(comments.size(), is(2));
-            assertThat(comments.get(0).getBody(), containsString("1"));
-            assertThat(comments.get(1).getBody(), containsString("2"));
+            assertThat(comments.get(0).getBody(), containsString(TICKET_COMMENT1));
+            assertThat(comments.get(1).getBody(), containsString(TICKET_COMMENT2));
         } finally {
             if (ticket != null) {
                 instance.deleteTicket(ticket.getId());
@@ -1217,24 +1504,233 @@ public class RealSmokeTest {
     public void getTicketCommentsDescending() throws Exception {
         createClientWithTokenOrPassword();
 
-        Ticket t = new Ticket(
-              new Ticket.Requester(config.getProperty("requester.name"), config.getProperty("requester.email")),
-              "This is an automated test ticket", new Comment("1"));
+        Ticket t = newTestTicket();
         Ticket ticket = null;
         try {
             ticket = instance.createTicket(t);
-            instance.createComment(ticket.getId(), new Comment("2"));
+            instance.createComment(ticket.getId(), new Comment(TICKET_COMMENT2));
             Iterable<Comment> ticketCommentsIt = instance.getTicketComments(ticket.getId(), SortOrder.DESCENDING);
             List<Comment> comments = new ArrayList<>();
             ticketCommentsIt.forEach(comments::add);
 
             assertThat(comments.size(), is(2));
-            assertThat(comments.get(0).getBody(), containsString("2"));
-            assertThat(comments.get(1).getBody(), containsString("1"));
+            assertThat(comments.get(0).getBody(), containsString(TICKET_COMMENT2));
+            assertThat(comments.get(1).getBody(), containsString(TICKET_COMMENT1));
         } finally {
             if (ticket != null) {
                 instance.deleteTicket(ticket.getId());
             }
         }
     }
+
+    // UTILITIES
+
+    /**
+     * Creates in zendesk few organizations (2 entries min, 5 entries max) and verify their existence.
+     *
+     * @return The new organizations
+     */
+    private List<Organization> createTestOrganizationsInZendesk() {
+        final Organization[] orgsToCreate = newTestOrganizations();
+        final Long[] createdOrgsIds = waitJobCompletion(instance.createOrganizations(orgsToCreate))
+                .getResults()
+                .stream()
+                .map(JobResult::getId)
+                .toArray(Long[]::new);
+        assumeThat("All created organizations should have an ID", createdOrgsIds.length, is(orgsToCreate.length));
+        final List<Organization> createdOrganizations = Arrays.stream(createdOrgsIds)
+                .map(instance::getOrganization)
+                .collect(Collectors.toList());
+        assumeThat("All created organizations are found in zendesk",
+                createdOrganizations.stream().map(Organization::getId).collect(Collectors.toList()),
+                containsInAnyOrder(createdOrgsIds));
+        LOGGER.info("Test organizations: {}", Arrays.toString(createdOrgsIds));
+        return createdOrganizations;
+    }
+
+    /**
+     * Creates several new organizations (2 min, 5 max)
+     */
+    private Organization[] newTestOrganizations() {
+        final ArrayList<Organization> organizations = new ArrayList<>();
+        for (int i = 0; i < 2 + RANDOM.nextInt(3); i++) {
+            organizations.add(newTestOrganization());
+        }
+        return organizations.toArray(new Organization[0]);
+    }
+
+    /**
+     * Creates a new organization
+     */
+    private Organization newTestOrganization() {
+        final Organization organization = new Organization();
+        final String id = UUID.randomUUID().toString();
+        organization.setExternalId("org-" + id);
+        organization.setName("[zendesk-java-client] Organization " + id);
+        organization.setDetails("This organization is created by zendesk-java-client Integration Tests");
+        organization.setTags(Arrays.asList("zendesk-java-client", "smoke-test"));
+        return organization;
+    }
+
+    /**
+     * Creates in zendesk few users (2 entries min, 5 entries max) and verify their existence.
+     *
+     * @return The new users
+     */
+    private List<User> createTestUsersInZendesk() {
+        final User[] usersToCreate = newTestUsers();
+        final Long[] createdUsersIds = waitJobCompletion(instance.createUsers(usersToCreate))
+                .getResults()
+                .stream()
+                .map(JobResult::getId)
+                .toArray(Long[]::new);
+        assumeThat("All created users should have an ID", createdUsersIds.length, is(usersToCreate.length));
+        final List<User> createdUsers = Arrays.stream(createdUsersIds)
+                .map(instance::getUser)
+                .collect(Collectors.toList());
+        assumeThat("All created users are found in zendesk",
+                createdUsers.stream().map(User::getId).collect(Collectors.toList()),
+                containsInAnyOrder(createdUsersIds));
+        LOGGER.info("Test users: {}", Arrays.toString(createdUsersIds));
+        return createdUsers;
+    }
+
+    /**
+     * Creates several new users (2 min, 5 max)
+     */
+    private User[] newTestUsers() {
+        final ArrayList<User> users = new ArrayList<>();
+        for (int i = 0; i < 2 + RANDOM.nextInt(3); i++) {
+            users.add(newTestUser());
+        }
+        return users.toArray(new User[0]);
+    }
+
+    /**
+     * Creates a new user
+     */
+    private User newTestUser() {
+        final User user = new User();
+        final String id = UUID.randomUUID().toString();
+        user.setExternalId("user-" + id);
+        user.setName("[zendesk-java-client] User " + id);
+        user.setDetails("This user is created by zendesk-java-client Integration Tests");
+        user.setTags(Arrays.asList("zendesk-java-client", "smoke-test"));
+        user.setEmail(id + "@test.com");
+        return user;
+    }
+
+    /**
+     * Creates in zendesk few tickets (2 entries min, 5 entries max) and verify their existence.
+     *
+     * @return The new tickets
+     */
+    private List<Ticket> createTestTicketsInZendesk() {
+        final Ticket[] ticketsToCreate = newTestTickets();
+        final Long[] createdTicketsIds = waitJobCompletion(instance.createTickets(ticketsToCreate))
+                .getResults()
+                .stream()
+                .map(JobResult::getId)
+                .toArray(Long[]::new);
+        assumeThat("All created tickets should have an ID", createdTicketsIds.length, is(ticketsToCreate.length));
+        final List<Ticket> createdTickets =
+                instance.getTickets(firstElement(createdTicketsIds), otherElements(createdTicketsIds));
+        assumeThat("All created tickets are found in zendesk",
+                createdTickets.stream().map(Ticket::getId).collect(Collectors.toList()),
+                containsInAnyOrder(createdTicketsIds));
+        LOGGER.info("Test tickets: {}", Arrays.toString(createdTicketsIds));
+        return createdTickets;
+    }
+
+    /**
+     * Creates several new tickets (2 min, 5 max)
+     */
+    private Ticket[] newTestTickets() {
+        final ArrayList<Ticket> tickets = new ArrayList<>();
+        for (int i = 0; i < 2 + RANDOM.nextInt(3); i++) {
+            tickets.add(newTestTicket());
+        }
+        return tickets.toArray(new Ticket[0]);
+    }
+
+    /**
+     * Creates a new ticket
+     */
+    private Ticket newTestTicket() {
+        assumeThat("Must have a requester email", config.getProperty("requester.email"), notNullValue());
+        assumeThat("Must have a requester name", config.getProperty("requester.name"), notNullValue());
+        final Ticket ticket = new Ticket(
+                new Ticket.Requester(config.getProperty("requester.name"), config.getProperty("requester.email")),
+                "[zendesk-java-client] This is a test " + UUID.randomUUID().toString(),
+                new Comment(TICKET_COMMENT1));
+        ticket.setCollaborators(Arrays.asList(new Collaborator("Bob Example", "bob@example.org"),
+                new Collaborator("Alice Example", "alice@example.org")));
+        ticket.setTags(Arrays.asList("zendesk-java-client", "smoke-test"));
+        return ticket;
+    }
+
+    /**
+     * Wait until a given JobStatus is marked as completed
+     *
+     * @param result The Job result to verify
+     * @return The completed job result
+     */
+    private JobStatus waitJobCompletion(final JobStatus result) {
+        // Let's validate the first result
+        assertNotNull(result);
+        assertNotNull(result.getId());
+        assertNotNull(result.getStatus());
+
+        // Let's wait for its completion (5 seconds max)
+        await().atMost(10, TimeUnit.SECONDS).until(() ->
+                instance.getJobStatus(result).getStatus() == JobStatus.JobStatusEnum.completed);
+
+        // Let's validate and return the completed result
+        final JobStatus completedResult = instance.getJobStatus(result);
+        assertNotNull(completedResult);
+        assertNotNull(completedResult.getId());
+        assertNotNull(completedResult.getStatus());
+        LOGGER.info("Completed Job Result: {}", completedResult);
+        return completedResult;
+    }
+
+    /**
+     * Wait to have a ticket listed in the deleted tickets end-point
+     *
+     * @param ticketId The identifier of the ticket to delete
+     */
+    private void waitTicketDeleted(long ticketId) {
+        // Wait for the confirmation
+        await().atMost(10, TimeUnit.SECONDS).until(() -> StreamSupport
+                .stream(instance.getDeletedTickets("id", SortOrder.DESCENDING).spliterator(), false)
+                .map(DeletedTicket::getId)
+                .collect(Collectors.toList())
+                .contains(ticketId));
+    }
+
+    /**
+     * Wait to have the tickets listed in the deleted tickets end-point
+     *
+     * @param ticketsIds The identifier of tickets to delete
+     */
+    private void waitTicketsDeleted(Long[] ticketsIds) {
+        // Wait for the confirmation
+        await().atMost(10, TimeUnit.SECONDS).until(() -> StreamSupport
+                .stream(instance.getDeletedTickets("id", SortOrder.DESCENDING).spliterator(), false)
+                .map(DeletedTicket::getId)
+                .collect(Collectors.toList())
+                .containsAll(Arrays.asList(ticketsIds)));
+    }
+
+    private long firstElement(Long[] array) {
+        return array[0];
+    }
+
+    private long[] otherElements(Long[] array) {
+        return Arrays.stream(Arrays.copyOfRange(array, 1, array.length))
+                .filter(Objects::nonNull)
+                .mapToLong(Long::longValue)
+                .toArray();
+    }
+
 }


### PR DESCRIPTION
Should solve: #47 #96  #98 #245

* New `deleteOrganizationMemberships` method
* New `createOrganizationMemberships` methods
* New `updateOrganizations` methods
* New `updateUsers` methods
* New `createOrUpdateUsers` methods
* [Breaking Change] `permanentlyDeleteTicket(s)` methods aren't calling anymore `deleteTicket(s)` because the deletion must be acked (and it's not necessarily immediate) before deleting them permanently
* [Breaking Change] New integration tests + **rework the model used to handle Async Jobs results** ( https://developer.zendesk.com/rest_api/docs/support/job_statuses#job-statuses )

