### PR TITLE
RealSmokeTest#createOrganization test was failing

### DIFF
--- a/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
+++ b/src/test/java/org/zendesk/client/v2/RealSmokeTest.java
@@ -1060,10 +1060,8 @@ public class RealSmokeTest {
         createClientWithTokenOrPassword();
 
         // Clean up to avoid conflicts
-        for (Organization t : instance.getOrganizations()) {
-            if ("testorg".equals(t.getExternalId())) {
-                instance.deleteOrganization(t);
-            }
+        for (Organization t : instance.lookupOrganizationsByExternalId("testorg")) {
+            instance.deleteOrganization(t);
         }
 
         Organization org = new Organization();


### PR DESCRIPTION
Because it was too long to review in 30sec all organizations to delete the ones with a given externalId

We now directly search for these specific orgs to delete them