### PR TITLE
Fix comment parsing without an explicit `type` present

### DIFF
--- a/src/main/java/org/zendesk/client/v2/model/Comment.java
+++ b/src/main/java/org/zendesk/client/v2/model/Comment.java
@@ -3,6 +3,7 @@ package org.zendesk.client.v2.model;
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.As.EXTERNAL_PROPERTY;
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -16,12 +17,18 @@ import org.zendesk.client.v2.model.comments.VoiceComment;
  * @author stephenc
  * @since 09/04/2013 15:09
  */
-@JsonTypeInfo(use = NAME, include = EXTERNAL_PROPERTY, property = "type", visible = true)
+@JsonTypeInfo(
+    use = NAME,
+    include = EXTERNAL_PROPERTY,
+    property = "type",
+    defaultImpl = Comment.class,
+    visible = true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Comment.class, name = "Comment"),
   @JsonSubTypes.Type(value = VoiceComment.class, name = "VoiceComment"),
   @JsonSubTypes.Type(value = VoiceComment.class, name = "TpeVoiceComment")
 })
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Comment implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/src/main/java/org/zendesk/client/v2/model/comments/VoiceComment.java
+++ b/src/main/java/org/zendesk/client/v2/model/comments/VoiceComment.java
@@ -1,8 +1,10 @@
 package org.zendesk.client.v2.model.comments;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.zendesk.client.v2.model.Comment;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class VoiceComment extends Comment {
 
   private VoiceCommentData data;

--- a/src/test/java/org/zendesk/client/v2/model/CommentTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/CommentTest.java
@@ -71,20 +71,20 @@ public class CommentTest {
 
   private static String createCommentJson(@Nullable String type) throws JsonProcessingException {
     // https://developer.zendesk.com/documentation/ticketing/managing-tickets/adding-voice-comments-to-tickets/
-    ObjectNode voiceData = MAPPER.createObjectNode()
-        .put("from", "+16617480240")
-        .put("to", "+16617480123")
-        .put("recording_url", COMMENT_VOICE_URL)
-        .put("started_at", "2019-04-16T09:14:57Z")
-        .put("call_duration", 42)
-        .put("answered_by_id", 28765)
-        .put("transcription_text", "The transcription of the call")
-        .put("location", "Topeka, Kansas");
+    ObjectNode voiceData =
+        MAPPER
+            .createObjectNode()
+            .put("from", "+16617480240")
+            .put("to", "+16617480123")
+            .put("recording_url", COMMENT_VOICE_URL)
+            .put("started_at", "2019-04-16T09:14:57Z")
+            .put("call_duration", 42)
+            .put("answered_by_id", 28765)
+            .put("transcription_text", "The transcription of the call")
+            .put("location", "Topeka, Kansas");
 
-    ObjectNode res = MAPPER.createObjectNode()
-        .put("id", COMMENT_ID)
-        .put("body", "Foo")
-        .set("data", voiceData);
+    ObjectNode res =
+        MAPPER.createObjectNode().put("id", COMMENT_ID).put("body", "Foo").set("data", voiceData);
 
     if (type != null) {
       res.put("type", type);

--- a/src/test/java/org/zendesk/client/v2/model/CommentTest.java
+++ b/src/test/java/org/zendesk/client/v2/model/CommentTest.java
@@ -1,0 +1,99 @@
+package org.zendesk.client.v2.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.function.Function;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+import org.zendesk.client.v2.Zendesk;
+import org.zendesk.client.v2.model.comments.VoiceComment;
+
+public class CommentTest {
+
+  private static final long COMMENT_ID = 123L;
+  private static final String COMMENT_BODY = "Foo";
+  private static final String COMMENT_VOICE_URL = "http://yourdomain.com/recordings/1.mp3";
+
+  private static final ObjectMapper MAPPER = Zendesk.createMapper(Function.identity());
+
+  @Test
+  public void defaultType() throws JsonProcessingException {
+    String json = createCommentJson(null);
+    Comment comment = parseJson(json);
+    assertEquals(Comment.class, comment.getClass());
+    assertEquals(Long.valueOf(COMMENT_ID), comment.getId());
+    assertEquals(COMMENT_BODY, comment.getBody());
+  }
+
+  @Test
+  public void explicitTypeComment() throws JsonProcessingException {
+    String json = createCommentJson("Comment");
+    Comment comment = parseJson(json);
+    assertEquals(Comment.class, comment.getClass());
+    assertEquals(Long.valueOf(COMMENT_ID), comment.getId());
+    assertEquals(COMMENT_BODY, comment.getBody());
+  }
+
+  @Test
+  public void explicitTypeVoiceComment() throws JsonProcessingException {
+    String json = createCommentJson("VoiceComment");
+    Comment comment = parseJson(json);
+    assertEquals(VoiceComment.class, comment.getClass());
+
+    VoiceComment voiceComment = (VoiceComment) comment;
+    assertEquals(Long.valueOf(COMMENT_ID), voiceComment.getId());
+    assertEquals(COMMENT_BODY, voiceComment.getBody());
+    assertEquals(COMMENT_VOICE_URL, voiceComment.getData().getRecordingUrl());
+  }
+
+  @Test
+  public void explicitTypeTpeVoiceCommentType() throws JsonProcessingException {
+    String json = createCommentJson("TpeVoiceComment");
+    Comment comment = parseJson(json);
+    assertEquals(VoiceComment.class, comment.getClass());
+
+    VoiceComment voiceComment = (VoiceComment) comment;
+    assertEquals(Long.valueOf(COMMENT_ID), voiceComment.getId());
+    assertEquals(COMMENT_BODY, voiceComment.getBody());
+    assertEquals(COMMENT_VOICE_URL, voiceComment.getData().getRecordingUrl());
+  }
+
+  @Test
+  public void invalidType() throws JsonProcessingException {
+    String json = createCommentJson("InvalidCommentType");
+    assertThrows(InvalidFormatException.class, () -> parseJson(json));
+  }
+
+  private static String createCommentJson(@Nullable String type) throws JsonProcessingException {
+    // https://developer.zendesk.com/documentation/ticketing/managing-tickets/adding-voice-comments-to-tickets/
+    ObjectNode voiceData = MAPPER.createObjectNode()
+        .put("from", "+16617480240")
+        .put("to", "+16617480123")
+        .put("recording_url", COMMENT_VOICE_URL)
+        .put("started_at", "2019-04-16T09:14:57Z")
+        .put("call_duration", 42)
+        .put("answered_by_id", 28765)
+        .put("transcription_text", "The transcription of the call")
+        .put("location", "Topeka, Kansas");
+
+    ObjectNode res = MAPPER.createObjectNode()
+        .put("id", COMMENT_ID)
+        .put("body", "Foo")
+        .set("data", voiceData);
+
+    if (type != null) {
+      res.put("type", type);
+    }
+
+    return MAPPER.writeValueAsString(res);
+  }
+
+  private static Comment parseJson(String json) throws JsonProcessingException {
+    return MAPPER.readValue(json, Comment.class);
+  }
+}


### PR DESCRIPTION
The `type` field is not mandatory for comments as per https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_comments/#json-format

Normally, that doesn't matter for parsing because the type is always there - except when dry running a macro: https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/#show-ticket-after-changes

I don't know why, but I did encounter this problem in production after having updated from a very ancient version that didn't use to annotate `Comment` with `@JsonTypeInfo`.

This PR fixes the problem by adding `defaultImpl = Comment.class` to the annotation, which makes Jackson use the base class by default when no type is given. I also added unit tests to verify this behaviour.